### PR TITLE
feat(dast): add container-mode support, command sanitation, and enfor…

### DIFF
--- a/aspm_cli/cli.py
+++ b/aspm_cli/cli.py
@@ -101,8 +101,8 @@ def run_scan(args):
             scanner = SASTScanner(args.repo_url, args.commit_ref, args.commit_sha, args.pipeline_id, args.job_url)
             data_type = "SG"
         elif args.scantype.lower() == "dast":
-            validator.validate_dast_scan(args.target_url, args.severity_threshold, args.dast_scan_type)
-            scanner = DASTScanner(args.target_url, args.severity_threshold, args.dast_scan_type)
+            validator.validate_dast_scan(args.command, args.severity_threshold, args.container_mode)
+            scanner = DASTScanner(args.command, args.severity_threshold, args.container_mode)
             data_type = "ZAP"
         else:
             Logger.get_logger().error("Invalid scan type.")
@@ -194,21 +194,20 @@ def add_secret_scan_args(parser):
     )
 
 def add_dast_scan_args(parser):
-    """Add arguments specific to DAST scan."""
-    parser.add_argument(
-        "--target-url",
-        required=True,
-        help="The target web application URL to scan (must start with http or https)"
-    )
     parser.add_argument(
         "--severity-threshold",
         default="High",
         help="Severity level to fail the scan. Allowed values: LOW, MEDIUM, HIGH. Default is HIGH"
     )
     parser.add_argument(
-        "--dast-scan-type",
-        default="baseline",
-        help="DAST scan type to run. Allowed values: baseline, full-scan. Default is baseline"
+        "--command",
+        required=True,
+        help="Arguments to pass to the DAST scanner (e.g., 'zap-baseline.py -t https://example.com -I')"
+    )
+    parser.add_argument(
+        "--container-mode",
+        action="store_true",
+        help="Run in container mode"
     )
 
 def add_download_args(subparser):

--- a/aspm_cli/utils/validation.py
+++ b/aspm_cli/utils/validation.py
@@ -67,16 +67,9 @@ class IaCScannerConfig(BaseModel):
         return v
 
 class DASTScannerConfig(BaseModel):
-    TARGET_URL: str
     SEVERITY_THRESHOLD: str
-    DAST_SCAN_TYPE: str
-
-    @field_validator("TARGET_URL", mode="before")
-    @classmethod
-    def validate_target_url(cls, v):
-        if not isinstance(v, str) or not v.startswith("http"):
-            raise ValueError("Invalid TARGET_URL. It must be a valid URL starting with 'http'.")
-        return v
+    COMMAND: str
+    CONTAINER_MODE: bool
 
     @field_validator("SEVERITY_THRESHOLD", mode="before")
     @classmethod
@@ -84,14 +77,6 @@ class DASTScannerConfig(BaseModel):
         allowed = {"HIGH", "MEDIUM", "LOW"}
         if v and v.upper() not in allowed:
             raise ValueError(f"Invalid SEVERITY_THRESHOLD '{v}'. Allowed values: {', '.join(allowed)}.")
-        return v
-
-    @field_validator("DAST_SCAN_TYPE", mode="before")
-    @classmethod
-    def validate_scan_type(cls, v):
-        allowed = {"baseline", "full-scan"}
-        if v and v.lower() not in allowed:
-            raise ValueError(f"Invalid DAST_SCAN_TYPE '{v}'. Allowed values: {', '.join(allowed)}.")
         return v
 
 class SASTScannerConfig(BaseModel):
@@ -243,12 +228,12 @@ class ConfigValidator:
                 Logger.get_logger().error(f"{error['loc'][0]}: {error['msg']}")
             sys.exit(1)
 
-    def validate_dast_scan(self, target_url, severity_threshold, dast_scan_type):
+    def validate_dast_scan(self, command, severity_threshold, container_mode):
         try:
             self.config = DASTScannerConfig(
-                TARGET_URL=target_url,
                 SEVERITY_THRESHOLD=severity_threshold,
-                DAST_SCAN_TYPE=dast_scan_type,
+                COMMAND=command,
+                CONTAINER_MODE=container_mode,
             )
         except ValidationError as e:
             for error in e.errors():


### PR DESCRIPTION
…ce JSON output

- Introduced --command to allow passing raw ZAP CLI args
- Added --container-mode flag (currently only container mode is supported)
- Improved error message when container mode is not enabled
- Sanitized conflicting report flags (-r, -w, -x, -J) from user command
- Enforced consistent JSON reporting with -J results.json