### PR TITLE
Add support for ZAP report templates to include request/response in DAST results

### DIFF
--- a/aspm_cli/cli.py
+++ b/aspm_cli/cli.py
@@ -103,7 +103,7 @@ def run_scan(args):
             data_type = "SG"
         elif args.scantype.lower() == "dast":
             validator.validate_dast_scan(args.command, args.severity_threshold, args.container_mode)
-            scanner = DASTScanner(args.command, args.severity_threshold, args.container_mode)
+            scanner = DASTScanner(args.command, args.severity_threshold, args.container_mode, args.report_template)
             data_type = "ZAP"
         else:
             Logger.get_logger().error("Invalid scan type.")
@@ -228,6 +228,10 @@ def add_dast_scan_args(parser):
         "--container-mode",
         action="store_true",
         help="Run in container mode"
+    )
+    parser.add_argument(
+        "--report-template",
+        help="ZAP Reporting template to include request/response (e.g., 'traditional-json-plus'). Overrides ZAP_REPORT_TEMPLATE env var if set."
     )
 
 def add_download_args(subparser):

--- a/aspm_cli/scan/dast.py
+++ b/aspm_cli/scan/dast.py
@@ -11,17 +11,26 @@ from aspm_cli.tool.manager import ToolManager
 class DASTScanner:
     zap_image = os.getenv("SCAN_IMAGE", "public.ecr.aws/k9v9d5v2/zaproxy/zap-stable:2.16.1")
     result_file = "results.json"
+    report_template = os.getenv("ZAP_REPORT_TEMPLATE")  # default from env, can be overridden via CLI
 
-    def __init__(self, command="", severity_threshold=None, container_mode=True):
+    def __init__(self, command="", severity_threshold=None, container_mode=True, report_template=None):
         """
         :param command: Raw CLI args string for zap scripts
                         Example: "zap-baseline.py -t https://example.com -J results.json -I"
         :param severity_threshold: Minimum severity to fail on ("High", "Medium", "Low", "Informational")
         :param container_mode: Currently only container mode is supported
+        :param report_template: Optional ZAP Reporting template (e.g., "traditional-json-plus")
+                               Requires container_mode=True
         """
         self.command = command
         self.severity_threshold = severity_threshold
         self.container_mode = container_mode
+        # Prefer CLI-provided template, fallback to env var
+        self.report_template = report_template or self.report_template
+        
+        # Validate: Template requires container mode
+        if self.report_template and not container_mode:
+            raise ValueError("Report template requires container_mode=True. Automation Framework is only supported in container mode.")
 
     def run(self):
         try:
@@ -29,6 +38,7 @@ class DASTScanner:
                 docker_pull(self.zap_image)
                 Logger.get_logger().debug("Starting DAST scan...")
 
+            # If a report template is requested, prepare Automation Framework yaml
             sanitized_args = self._build_dast_args()
             cmd, env = self._build_dast_command(sanitized_args)
 
@@ -87,13 +97,71 @@ class DASTScanner:
             sanitized_args.append(args[i])
             i += 1
 
-        if "zap-baseline.py" in shlex.join(args) or "zap-full-scan.py" in shlex.join(args):
-            # Always enforce JSON report at results.json
-            sanitized_args.extend([
-                "-J", os.path.basename(self.result_file)
-            ])
+        use_automation = False
+        target_url = None
+        joined = shlex.join(args)
+
+        if "zap-baseline.py" in joined or "zap-full-scan.py" in joined:
+            # Extract target url if present after -t
+            try:
+                t_index = args.index("-t")
+                if t_index + 1 < len(args):
+                    target_url = args[t_index + 1]
+            except ValueError:
+                pass
+
+            # If a report template is requested, switch to Automation Framework
+            if (self.report_template or "").strip() and target_url:
+                self._write_zap_automation_yaml(target_url)
+                use_automation = True
+            else:
+                # Fallback to baseline/full-scan with JSON output
+                sanitized_args.extend(["-J", os.path.basename(self.result_file)])
+
+        if use_automation:
+            # Build args to run automation framework
+            sanitized_args = [
+                "zap.sh", "-cmd", "-autorun", "/zap/wrk/zap.yaml"
+            ]
 
         return sanitized_args
+
+    def _write_zap_automation_yaml(self, target_url: str):
+        """
+        Write a minimal ZAP Automation Framework YAML to generate a report using
+        the specified template directly to /zap/wrk/results.json (mounted cwd).
+        """
+        try:
+            yaml_content = f"""
+env:
+  contexts:
+    - name: ctx
+      urls:
+        - {target_url}
+  parameters: {{}}
+  vars: {{}}
+jobs:
+  - type: spider
+    parameters:
+      context: ctx
+      url: {target_url}
+      maxDuration: 1
+  - type: passiveScan-wait
+  - type: report
+    parameters:
+      template: {self.report_template}
+      reportDir: /zap/wrk
+      reportFile: results.json
+      reportTitle: DAST
+            """.lstrip()
+
+            with open("zap.yaml", "w") as f:
+                f.write(yaml_content)
+            # Ensure our scanner expects the AF report output
+            self.result_file = "results.json"
+            Logger.get_logger().debug("Wrote ZAP Automation Framework yaml to zap.yaml")
+        except Exception as e:
+            Logger.get_logger().error(f"Failed writing zap.yaml: {e}")
 
     def _build_dast_command(self, args):
         env = os.environ.copy()
@@ -148,3 +216,5 @@ class DASTScanner:
         except Exception as e:
             Logger.get_logger().error(f"Error evaluating DAST results: {e}")
             return 1
+
+    


### PR DESCRIPTION
### What changed:

- Added --report-template CLI flag to specify a ZAP Reporting template (e.g., traditional-json-plus).
- Added support for ZAP_REPORT_TEMPLATE environment variable as fallback.
- When a template is provided, the CLI switches from zap-baseline.py to ZAP Automation Framework.
- Auto-generates zap.yaml with context, spider, passive scan, and report job.
- Without a template, baseline behavior is unchanged.

### Files modified:

- aspm_cli/cli.py - Added --report-template argument and passed it to DASTScanner.
- aspm_cli/scan/dast.py - Added Automation Framework logic, YAML generation, and template validation.

### How it works:

- If --report-template or ZAP_REPORT_TEMPLATE is set, extract target URL from -t flag.
- Generate zap.yaml with Automation Framework configuration.
- Run zap.sh -cmd -autorun /zap/wrk/zap.yaml instead of zap-baseline.py.
- ZAP generates results.json with request/response fields (request-header, request-body, response-header, response-body).