### PR TITLE
added report-template flag to scanner to get req/response in dast scan

### DIFF
--- a/aspm_cli/scanners/dast_scanner.py
+++ b/aspm_cli/scanners/dast_scanner.py
@@ -23,10 +23,14 @@ class DASTScanner(BaseScanner):
             action="store_true",
             help="Run in container mode"
         )
+        parser.add_argument(
+            "--report-template",
+            help="ZAP Reporting template to include request/response (e.g., 'traditional-json-plus'). Overrides ZAP_REPORT_TEMPLATE env var if set."
+        )
 
     def validate_config(self, args: argparse.Namespace, validator: ConfigValidator):
         validator.validate_dast_scan(args.command, args.severity_threshold, args.container_mode)
 
     def run_scan(self, args: argparse.Namespace) -> tuple[int, str]:
-        scanner = OriginalDASTScanner(args.command, args.severity_threshold, args.container_mode)
+        scanner = OriginalDASTScanner(args.command, args.severity_threshold, args.container_mode, args.report_template)
         return scanner.run()


### PR DESCRIPTION
### What changed:

- Added --report-template CLI flag to specify a ZAP Reporting template (e.g., traditional-json-plus).
- Added support for ZAP_REPORT_TEMPLATE environment variable as fallback.
- When a template is provided, the CLI switches from zap-baseline.py to ZAP Automation Framework.
- Auto-generates zap.yaml with context, spider, passive scan, and report job.
- Without a template, baseline behavior is unchanged.

### Files modified:

- aspm_cli/scanners/dast_scanner.py - Added --report-template argument and passed it to DASTScanner.
- aspm_cli/scan/dast.py - Added Automation Framework logic, YAML generation, and template validation.

### How it works:

- If --report-template or ZAP_REPORT_TEMPLATE is set, extract target URL from -t flag.
- Generate zap.yaml with Automation Framework configuration.
- Run zap.sh -cmd -autorun /zap/wrk/zap.yaml instead of zap-baseline.py.
- ZAP generates results.json with request/response fields (request-header, request-body, response-header, response-body).