### PR TITLE
feat: Add global pre-commit hook installation support

### DIFF
--- a/aspm_cli/commands/precommit_command.py
+++ b/aspm_cli/commands/precommit_command.py
@@ -10,10 +10,22 @@ class PreCommitCommand(BaseCommand):
         install_parser = subparsers.add_parser(
             "install", help="Install pre-commit hooks"
         )
+        install_parser.add_argument(
+            "--global",
+            dest="global_install",
+            action="store_true",
+            help="Install a single pre-commit hook globally for all git repositories (sets git config core.hooksPath).",
+        )
         install_parser.set_defaults(func=self.execute) 
 
         uninstall_parser = subparsers.add_parser(
             "uninstall", help="Uninstall pre-commit hooks"
+        )
+        uninstall_parser.add_argument(
+            "--global",
+            dest="global_install",
+            action="store_true",
+            help="Uninstall the globally installed pre-commit hook (restores git config core.hooksPath).",
         )
         uninstall_parser.set_defaults(func=self.execute)
 

--- a/aspm_cli/pre_commit_wrapper/config.py
+++ b/aspm_cli/pre_commit_wrapper/config.py
@@ -3,6 +3,8 @@ from pre_commit.store import Store
 from pre_commit import git
 from pre_commit.constants import CONFIG_FILE
 import os
+import subprocess
+from pathlib import Path
 
 PRE_COMMIT_CONTENT = """repos:
   - repo: local
@@ -16,29 +18,96 @@ PRE_COMMIT_CONTENT = """repos:
         pass_filenames: false
 """
 
-# TODO: precommit global support, display the findings, remove results.json file
+GLOBAL_HOOKS_DIR = Path.home() / ".accuknox" / "git-hooks"
+GLOBAL_HOOK_FILE = GLOBAL_HOOKS_DIR / "pre-commit"
+GLOBAL_BACKUP_FILE = GLOBAL_HOOKS_DIR / ".core.hooksPath.bak"
+
+GLOBAL_HOOK_SCRIPT = """#!/usr/bin/env bash
+set -euo pipefail
+
+# AccuKnox Secret Scan (global pre-commit hook)
+# Runs in the context of the current repository.
+accuknox-aspm-scanner scan --skip-upload secret --command "git file://." --container-mode
+"""
+
+def _git_config_global_get(key: str) -> str:
+    result = subprocess.run(
+        ["git", "config", "--global", "--get", key],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return (result.stdout or "").strip()
+
+def _git_config_global_set(key: str, value: str) -> None:
+    subprocess.run(["git", "config", "--global", key, value], check=False)
+
+def _git_config_global_unset(key: str) -> None:
+    subprocess.run(["git", "config", "--global", "--unset", key], check=False)
+
+def _write_executable(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    path.chmod(0o755)
+
+def _install_global_hook() -> int:
+    # Backup existing hooksPath, if any
+    existing = _git_config_global_get("core.hooksPath")
+    GLOBAL_HOOKS_DIR.mkdir(parents=True, exist_ok=True)
+    if existing:
+        GLOBAL_BACKUP_FILE.write_text(existing)
+    else:
+        # clear any previous backup so uninstall doesn't restore stale values
+        if GLOBAL_BACKUP_FILE.exists():
+            GLOBAL_BACKUP_FILE.unlink()
+
+    _write_executable(GLOBAL_HOOK_FILE, GLOBAL_HOOK_SCRIPT)
+    _git_config_global_set("core.hooksPath", str(GLOBAL_HOOKS_DIR))
+    return 0
+
+def _uninstall_global_hook() -> int:
+    # Restore previous hooksPath if we have a backup, else unset.
+    if GLOBAL_BACKUP_FILE.exists():
+        previous = GLOBAL_BACKUP_FILE.read_text().strip()
+        if previous:
+            _git_config_global_set("core.hooksPath", previous)
+        else:
+            _git_config_global_unset("core.hooksPath")
+        GLOBAL_BACKUP_FILE.unlink(missing_ok=True)
+    else:
+        _git_config_global_unset("core.hooksPath")
+
+    # Remove hook script
+    if GLOBAL_HOOK_FILE.exists():
+        GLOBAL_HOOK_FILE.unlink()
+    return 0
+
+# TODO: display the findings, remove results.json file
 def handle_pre_commit(args):
 
     try:
         store = Store()
         git.check_for_cygwin_mismatch()
 
-        # create .pre-commit-config.yaml
-        with open(CONFIG_FILE, "w") as f:
-            f.write(PRE_COMMIT_CONTENT)
-
         if args.precommit_cmd == "install":
-            exit_code = install(
-                CONFIG_FILE,
-                store,
-                hook_types=None,
-                overwrite=True,
-                hooks=True,
-                # global_install if later supported
-                # global_install=args.global
-            )
+            if getattr(args, "global_install", False):
+                exit_code = _install_global_hook()
+            else:
+                # create .pre-commit-config.yaml
+                with open(CONFIG_FILE, "w") as f:
+                    f.write(PRE_COMMIT_CONTENT)
+                exit_code = install(
+                    CONFIG_FILE,
+                    store,
+                    hook_types=None,
+                    overwrite=True,
+                    hooks=True,
+                )
         elif args.precommit_cmd == "uninstall":
-            exit_code = uninstall(config_file=CONFIG_FILE, hook_types=None)
+            if getattr(args, "global_install", False):
+                exit_code = _uninstall_global_hook()
+            else:
+                exit_code = uninstall(config_file=CONFIG_FILE, hook_types=None)
         else:
             exit_code = 1
 


### PR DESCRIPTION
- Add --global flag to pre-commit install/uninstall commands
- Implement global hook installation using git config core.hooksPath
- Create global hook script at ~/.accuknox/git-hooks/pre-commit
- Backup and restore existing hooksPath configuration
- Maintain backward compatibility with per-repo installation