### PR TITLE
Add keep-results flag and enhance debug logging

### DIFF
--- a/aspm_cli/utils/config.py
+++ b/aspm_cli/utils/config.py
@@ -4,6 +4,10 @@ from typing import Optional, Literal
 from aspm_cli.utils.logger import Logger
 from aspm_cli.utils.common import ALLOWED_SCAN_TYPES
 
+# Return code constants
+PASS_RETURN_CODE = 0
+SOMETHING_WENT_WRONG_RETURN_CODE = 1
+
 def _format_validation_error(e: ValidationError) -> str:
     """Return a concise error summary (no verbose Pydantic metadata)."""
     errors = []


### PR DESCRIPTION

## Summary

Adds `--keep-results` flag and enhances debug logging for upload operations.

## Changes

1. **`--keep-results` flag**: Option to keep scan results file after completion (works with or without upload)
   - Supports CLI flag: `--keep-results`
   - Supports environment variable: `KEEP_RESULTS=TRUE`
   - Default behavior unchanged (files deleted by default)

2. **Enhanced debug logging**: Improved debugging information for upload requests, responses, and error handling
   - Added debug logs for upload URL, file size, parameters
   - Enhanced error logging for SSL, Connection, and Timeout errors

## Files Changed

- `aspm_cli/commands/scan_command.py` - Added flag and updated file cleanup logic
- `aspm_cli/utils/common.py` - Added `keep_file` parameter and debug logging
- `aspm_cli/utils/config.py` - Added return code constants

