### PR TITLE
Fix container scan result file permissions so SBOM enrichment can write project_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It integrates with the **AccuKnox ASPM Platform** but can also operate **complet
 ### 1. From PyPI (Cloud or Connected Environment)
 
 ```bash
-pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.8/accuknox_aspm_scanner-0.13.8-py3-none-any.whl
+pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.0/accuknox_aspm_scanner-0.14.0-py3-none-any.whl
 ````
 
 ### 2. From Precompiled Package (On-Prem Setup)
@@ -49,6 +49,7 @@ The following variables are supported for configuration (accuknox vars are optio
 | `ACCUKNOX_TOKEN`    | Authentication token for the AccuKnox platform                                         |
 | `ASPM_DEBUG`        | Set to `TRUE` to enable verbose trace output                                           |
 | `SCAN_IMAGE`        | Override internal Docker images for on-prem scanners (e.g., `myregistry/accuknox-iac:latest`) |
+| `KEEP_RESULTS`      | Set to `TRUE` to keep scan results file after completion                               |
 
 > 💡 Use `--skip-upload` to disable result upload to the AccuKnox platform — useful for local testing or isolated environments.
 
@@ -111,9 +112,35 @@ accuknox-aspm-scanner scan secret --command "git file://." --container-mode
 
 ### 🐳 Container Image Scanning
 
+Scan a container image for vulnerabilities:
+
 ```bash
-accuknox-aspm-scanner scan container --command "--image nginx:latest"
+accuknox-aspm-scanner scan container --command "image nginx:latest"
 ```
+
+#### Generate Software Bill of Materials (SBOM)
+
+Instead of scanning for vulnerabilities, you can generate an SBOM (Software Bill of Materials) in CycloneDX format:
+
+```bash
+accuknox-aspm-scanner scan \
+  --project-name "my-project" \
+  container \
+  --command "image nginx:latest" \
+  --generate-sbom
+```
+
+**What is SBOM?**  
+An SBOM is a complete inventory of all software components, libraries, and dependencies in your container image. It helps you:
+- Track all components and their versions
+- Understand your software supply chain
+- Meet compliance requirements
+- Identify affected components when vulnerabilities are disclosed
+
+**When to use `--generate-sbom`:**
+- When you need a complete inventory of all dependencies in your container
+- For compliance and supply chain security requirements
+- To track component versions across your container images
 
 ### 🌐 Dynamic Application Security Testing (DAST)
 
@@ -136,9 +163,53 @@ accuknox-aspm-scanner scan sq-sast --command "-Dsonar.projectKey='<PROJECT KEY>'
 | `--endpoint`                   | Control Plane URL (overrides env var)   |
 | `--label`                      | Label or project name                   |
 | `--token`                      | Authentication token                    |
+| `--project-name`               | Project name (required for SBOM uploads) |
 | `--skip-upload`                | Skip uploading results to Control Plane |
 | `--softfail`                   | Do not break CI/CD pipeline on findings |
 | `--container-mode`             | Run scanner inside a container          |
+| `--keep-results`               | Keep the scan results JSON file after completion (not deleted) |
+| `--generate-sbom`              | Generate SBOM instead of vulnerability scan (container scans only) |
+
+#### About `--keep-results`
+
+By default, the scan results JSON file (`results.json`) is automatically deleted after the scan completes (unless upload fails). Use `--keep-results` to preserve the file for later review or analysis.
+
+**When to use `--keep-results`:**
+- When you need to review scan results locally
+- For debugging and troubleshooting
+- When integrating with custom analysis tools
+- For audit and compliance record-keeping
+
+**Example:**
+```bash
+accuknox-aspm-scanner scan container \
+  --command "image nginx:latest" \
+  --keep-results
+```
+
+The results file will be saved as `results.json` in the current directory.
+
+#### About `--generate-sbom`
+
+The `--generate-sbom` flag is available for container scans. It generates a Software Bill of Materials (SBOM) in CycloneDX JSON format instead of running a vulnerability scan.
+
+**When to use `--generate-sbom`:**
+- When you need a complete inventory of all dependencies
+- For supply chain security and compliance
+- To track component versions across container images
+- For integration with SBOM analysis tools
+
+**Example:**
+```bash
+accuknox-aspm-scanner scan \
+  --project-name "my-application" \
+  container \
+  --command "image nginx:latest" \
+  --generate-sbom \
+  --keep-results
+```
+
+The SBOM will be saved as `results.json` in CycloneDX format. Use `--project-name` to tag the SBOM with your project identifier.
 
 ---
 
@@ -195,5 +266,56 @@ Enable verbose debug mode:
 ```bash
 DEBUG=TRUE accuknox-aspm-scanner scan iac --command "-d ."
 ```
+
+---
+
+## 🔧 Troubleshooting
+
+### GLIBC Version Compatibility Issue
+
+If you encounter an error like:
+```
+Failed to load Python shared library: version `GLIBC_2.38' not found
+```
+
+This means the binary was built on a system with a newer GLIBC version than your system supports.
+
+**Solutions:**
+
+1. **Use the Python wheel package instead** (recommended):
+   ```bash
+   pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v<version>/accuknox_aspm_scanner-<version>-py3-none-any.whl
+   ```
+
+2. **Build the binary locally using Docker** (for maximum compatibility):
+   ```bash
+   # Build using the Dockerfile.build (uses Ubuntu 20.04 for max compatibility)
+   docker build -f Dockerfile.build -t aspm-scanner-builder .
+   docker create --name builder aspm-scanner-builder
+   docker cp builder:/build/dist/accuknox-aspm-scanner ./dist/accuknox-aspm-scanner
+   docker rm builder
+   chmod +x ./dist/accuknox-aspm-scanner
+   ```
+
+3. **Build the binary locally on your system**:
+   ```bash
+   # Install dependencies
+   sudo apt-get update
+   sudo apt-get install -y python3.10 python3-pip python3-venv
+   
+   # Install pipenv
+   pip3 install pipenv
+   
+   # Install project dependencies
+   pipenv install
+   pipenv run pip install pyinstaller
+   
+   # Build the binary
+   pipenv run pyinstaller accuknox-aspm-scanner.spec
+   
+   # The binary will be in dist/accuknox-aspm-scanner
+   ```
+
+**Note:** Future releases are built using Docker with Ubuntu 20.04 (GLIBC 2.31) for maximum compatibility across Linux distributions. Binaries built on older systems work on newer systems (forward compatible).
 
 ---

--- a/aspm_cli/scan/container.py
+++ b/aspm_cli/scan/container.py
@@ -110,8 +110,12 @@ class ContainerScanner:
         if not self.container_mode:
             cmd = ([ToolManager.get_path("container")])
         else:
+            # Run as host user so result files are writable by the host process (for enrichment)
+            uid = os.getuid() if hasattr(os, "getuid") else 0
+            gid = os.getgid() if hasattr(os, "getgid") else 0
             cmd = [
                 "docker", "run", "--rm",
+                "--user", f"{uid}:{gid}",
                 "-v", "/var/run/docker.sock:/var/run/docker.sock",
                 "-v", f"{os.getcwd()}:/workdir",
                 "--workdir", "/workdir",


### PR DESCRIPTION
## Problem
When running a container scan with `--generate-sbom` and `--project-name`, the CLI can fail with:
`[Errno 13] Permission denied: './results.json'`

Trivy runs inside Docker as root, so it creates `results.json` (and any SBOM output) with root ownership. The host-side enrichment step that adds `project_name` and `project_classifier` to the SBOM then tries to open and write that file and fails because the host user does not own it.

## Solution
Run the Trivy container with the host user's uid/gid via `docker run --user <uid>:<gid>`. Result files are then created with the same owner as the process running the CLI, so enrichment can write to them without permission errors.

## Changes
- **`aspm_cli/scan/container.py`**: In `_build_scan_command()`, when `container_mode` is True, add `--user $(id -u):$(id -g)` (using `os.getuid()` / `os.getgid()`). On non-Unix (e.g. Windows without these), we fall back to `0:0` to preserve previous behavior.

## Testing
- Run container scan with `--container-mode` and `--generate-sbom` and `--project-name`; confirm `results.json` is writable by the host process and contains `project_name` and `project_classifier` after enrichment.
- Verify vuln-only container scan (no `--generate-sbom`) still works.
