### PR TITLE
chore: upgrade trivy version to 0.69.2

### DIFF
--- a/utils/prepare-aspm-scanners.sh
+++ b/utils/prepare-aspm-scanners.sh
@@ -42,7 +42,7 @@ echo "✅ Packaged as $SECRET_TAR"
 
 ### 3. Trivy -> container.tar.gz
 echo "=== [3/6] Downloading Trivy ==="
-TRIVY_VERSION="0.65.0"
+TRIVY_VERSION="0.69.2"
 TRIVY_URL="https://get.trivy.dev/trivy?type=tar.gz&version=${TRIVY_VERSION}&os=linux&arch=amd64"
 TRIVY_TAR="trivy.tar.gz"
 CONTAINER_BIN="container"


### PR DESCRIPTION
build-deb job is failing because Trivy release 0.65.0 is deleted.
Kubeshield uses [0.69.2](https://github.com/accuknox/kubesheild/blob/v0.3.10/Dockerfile#L56), so I've decided to use to same to maintain version standardization across tools.

