### PR TITLE
chore: migrate Trivy installation to accuknox fork

### DIFF
--- a/aspm_cli/scan/container.py
+++ b/aspm_cli/scan/container.py
@@ -9,7 +9,7 @@ from aspm_cli.utils import config
 from colorama import Fore
 
 class ContainerScanner:
-    ak_container_image = os.getenv("SCAN_IMAGE", "public.ecr.aws/k9v9d5v2/aquasec/trivy:0.65.0")
+    ak_container_image = os.getenv("SCAN_IMAGE", "public.ecr.aws/k9v9d5v2/accuknox/trivy:latest")
     result_file = './results.json'
 
     def __init__(self, command, container_mode=False, generate_sbom: bool = False):

--- a/aspm_cli/scan/container.py
+++ b/aspm_cli/scan/container.py
@@ -9,7 +9,7 @@ from aspm_cli.utils import config
 from colorama import Fore
 
 class ContainerScanner:
-    ak_container_image = os.getenv("SCAN_IMAGE", "public.ecr.aws/k9v9d5v2/accuknox/trivy:latest")
+    ak_container_image = os.getenv("SCAN_IMAGE", "public.ecr.aws/k9v9d5v2/accuknox/trivy:0.69.3")
     result_file = './results.json'
 
     def __init__(self, command, container_mode=False, generate_sbom: bool = False):

--- a/utils/prepare-aspm-scanners.sh
+++ b/utils/prepare-aspm-scanners.sh
@@ -42,8 +42,7 @@ echo "✅ Packaged as $SECRET_TAR"
 
 ### 3. Trivy -> container.tar.gz
 echo "=== [3/6] Downloading Trivy ==="
-TRIVY_VERSION=$(curl -s https://api.github.com/repos/accuknox/trivy/releases/latest \
-  | grep '"tag_name"' | cut -d'"' -f4 | sed 's/^v//')
+TRIVY_VERSION="0.69.3"
 TRIVY_TAR="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
 CONTAINER_BIN="container"
 mkdir -p temp_container_download

--- a/utils/prepare-aspm-scanners.sh
+++ b/utils/prepare-aspm-scanners.sh
@@ -42,14 +42,14 @@ echo "✅ Packaged as $SECRET_TAR"
 
 ### 3. Trivy -> container.tar.gz
 echo "=== [3/6] Downloading Trivy ==="
-TRIVY_VERSION="0.69.2"
-TRIVY_URL="https://get.trivy.dev/trivy?type=tar.gz&version=${TRIVY_VERSION}&os=linux&arch=amd64"
-TRIVY_TAR="trivy.tar.gz"
+TRIVY_VERSION=$(curl -s https://api.github.com/repos/accuknox/trivy/releases/latest \
+  | grep '"tag_name"' | cut -d'"' -f4 | sed 's/^v//')
+TRIVY_TAR="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
 CONTAINER_BIN="container"
 mkdir -p temp_container_download
 cd temp_container_download
-curl -L "$TRIVY_URL" -o "$TRIVY_TAR"
-tar -xzf "$TRIVY_TAR"
+curl -sfL "https://github.com/accuknox/trivy/releases/download/v${TRIVY_VERSION}/${TRIVY_TAR}" -o "$TRIVY_TAR"
+tar -xzf "$TRIVY_TAR" trivy
 chmod +x trivy
 cp trivy ../$CONTAINER_BIN
 cd ..


### PR DESCRIPTION
## Summary
- Replaces `get.trivy.dev` (upstream) binary download in `prepare-aspm-scanners.sh` with a dynamic latest-version download from `github.com/accuknox/trivy/releases`
- Removes hardcoded version `0.69.2` — builds now auto-pick the latest accuknox release at build time
- Replaces fallback ECR image in `container.py` from `public.ecr.aws/k9v9d5v2/aquasec/trivy:0.65.0` → `public.ecr.aws/k9v9d5v2/accuknox/trivy:latest`

