### PR TITLE
chore(release): bump version to 0.14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It integrates with the **AccuKnox ASPM Platform** but can also operate **complet
 ### 1. From PyPI (Cloud or Connected Environment)
 
 ```bash
-pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.8/accuknox_aspm_scanner-0.13.8-py3-none-any.whl
+pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.2/accuknox_aspm_scanner-0.14.2-py3-none-any.whl
 ````
 
 ### 2. From Precompiled Package (On-Prem Setup)

--- a/aspm_cli/utils/version.py
+++ b/aspm_cli/utils/version.py
@@ -1,2 +1,2 @@
 def get_version():
-    return '0.13.8'
+    return '0.14.2'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = accuknox-aspm-scanner
-version = 0.14.0
+version = 0.14.2
 description = AccuKnox ASPM Scanner
 author = AccuKnox
 author_email = accuknox@accuknox.com

--- a/utils/package/debian/changelog
+++ b/utils/package/debian/changelog
@@ -1,3 +1,10 @@
+aspm-scanner-cli (0.14.2) unstable; urgency=medium
+
+  * Align package and CLI version metadata for 0.14.2 release
+  * Update installation documentation to use v0.14.2 wheel
+
+ -- AccuKnox <accuknox@accuknox.com>  Wed, 15 Apr 2026 12:00:00 +0530
+
 aspm-scanner-cli (0.14.0) unstable; urgency=medium
 
   * Add --keep-results flag to keep scan results file after completion


### PR DESCRIPTION
- Bumps ASPM CLI release version to 0.14.2 across package metadata and runtime version reporting.
- Updates installation documentation to use the v0.14.2 wheel URL.
- Adds a new Debian changelog entry for 0.14.2 release notes.