### PR TITLE
Update README and on-prem usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ It can upload results to the **AccuKnox ASPM Platform**, but it can also run in 
 
 ## Features
 
-- One CLI for multiple scan types: IaC, SAST, SonarQube SAST, Secret, Container, and DAST
-- Supports both local tools and containerized execution
-- Optional upload to AccuKnox ASPM
-- Works in standalone and on-prem environments
-- Supports environment-variable and flag-based configuration
-- Supports pre-commit integration
+- 🚀 One CLI for multiple scan types: IaC, SAST, SonarQube SAST, Secret, Container, and DAST
+- 🔄 Supports both local tools and containerized execution
+- 🔐 Optional upload to AccuKnox ASPM
+- 🧰 Works in standalone and on-prem environments
+- 🧵 Supports environment-variable and flag-based configuration
+- 🧩 Supports pre-commit integration
 
 ## Installation
 
@@ -113,9 +113,9 @@ accuknox-aspm-scanner scan [flags-before-the-scan-name] <scan-name> --command "<
 Here is what each part means:
 
 - `scan`: tells the CLI you want to run a scan
-- `flags before the scan name`: these control the overall scan run, such as upload and result handling
+- `flags before the scan name`: these are common scan flags and work across all scan types
 - `<scan-name>`: one of `iac`, `sast`, `secret`, `container`, `dast`, or `sq-sast`
-- `flags after the scan name`: these belong only to that specific scanner
+- `flags after the scan name`: these are only for the selected scanner
 - `--command`: required for every scan and passed to the underlying scanner
 
 Simple rule:
@@ -488,7 +488,7 @@ accuknox-aspm-scanner scan --skip-upload --keep-results sq-sast --command "-Dson
 - Result files are deleted unless `--keep-results` is used
 - `tool install` downloads public artifacts, so fully restricted environments may need pre-staged local tools or mirrored images
 
-More detailed operational notes and workarounds are available in `docs/onprem-poc-runbook.md`.
+More detailed operational notes and workarounds are available in `docs/onprem-setup-guide.md`.
 
 ## Pre-Commit Integration
 

--- a/README.md
+++ b/README.md
@@ -2,198 +2,512 @@
 
 ![AccuKnox Logo](https://accuknox.com/wp-content/uploads/accuknox-logo-2.png)
 
-**`accuknox-aspm-scanner`** is a unified command-line interface for running application security scans (IaC, SAST, Secret, Container, and DAST) as part of your CI/CD or developer workflow.  
-It integrates with the **AccuKnox ASPM Platform** but can also operate **completely standalone** — ideal for on-premise or air-gapped environments.
+**`accuknox-aspm-scanner`** is a unified CLI for running IaC, SAST, SonarQube SAST, Secret, Container, and DAST scans in CI/CD pipelines or local developer workflows.
 
----
+It can upload results to the **AccuKnox ASPM Platform**, but it can also run in standalone mode for restricted or on-prem environments.
 
-## ✨ Features
+## Features
 
-- 🚀 One CLI for all security scan types: IaC, SAST, SonarQube SAST, Secret, Container, and DAST  
-- 🔄 Direct execution using containerized or local tools  
-- 🧩 Easy integration with CI/CD pipelines and pre-commit hooks  
-- 🔐 Push results to AccuKnox ASPM Platform (optional)  
-- 🧰 Fully offline/on-premise mode supported  
-- 🧵 Environment variable and argument-based configuration  
-- 🧾 Debug logging with full trace support
+- One CLI for multiple scan types: IaC, SAST, SonarQube SAST, Secret, Container, and DAST
+- Supports both local tools and containerized execution
+- Optional upload to AccuKnox ASPM
+- Works in standalone and on-prem environments
+- Supports environment-variable and flag-based configuration
+- Supports pre-commit integration
 
----
+## Installation
 
-## 🛠️ Installation
+### 1. Connected environment
 
-### 1. From PyPI (Cloud or Connected Environment)
+Install from the GitHub release wheel:
 
 ```bash
 pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.2/accuknox_aspm_scanner-0.14.2-py3-none-any.whl
-````
+```
 
-### 2. From Precompiled Package (On-Prem Setup)
+### 2. Restricted or on-prem environment
 
-For restricted environments, you can install the precompiled `.deb.gz` package provided by AccuKnox:
+Install from the release `.deb` package:
 
-![Releases](https://github.com/accuknox/aspm-scanner-cli/releases)
 ```bash
 sudo dpkg -i accuknox-aspm-scanner_<version>.deb
 ```
 
----
+## Get Help
 
-## ⚙️ Environment Variables
+Use standard CLI help:
 
-The following variables are supported for configuration (accuknox vars are optional if `--skip-upload` is used):
+```bash
+accuknox-aspm-scanner --help
+accuknox-aspm-scanner scan --help
+accuknox-aspm-scanner scan iac --help
+accuknox-aspm-scanner scan sast --help
+accuknox-aspm-scanner scan secret --help
+accuknox-aspm-scanner scan container --help
+accuknox-aspm-scanner scan dast --help
+accuknox-aspm-scanner scan sq-sast --help
+accuknox-aspm-scanner tool --help
+accuknox-aspm-scanner pre-commit --help
+```
 
-| Variable            | Description                                                                            |
-| ------------------- | -------------------------------------------------------------------------------------- |
-| `ACCUKNOX_ENDPOINT` | URL of the AccuKnox Control Plane API endpoint                                         |
-| `ACCUKNOX_LABEL`    | Label or project name to associate scan results                                        |
-| `ACCUKNOX_TOKEN`    | Authentication token for the AccuKnox platform                                         |
-| `ASPM_DEBUG`        | Set to `TRUE` to enable verbose trace output                                           |
-| `SCAN_IMAGE`        | Override internal Docker images for on-prem scanners (e.g., `myregistry/accuknox-iac:latest`) |
+If you are running directly from local source code:
 
-> 💡 Use `--skip-upload` to disable result upload to the AccuKnox platform — useful for local testing or isolated environments.
+```bash
+python -m aspm_cli.cli --help
+```
 
----
+## Environment Variables
 
-## 🧩 Commands Overview
+AccuKnox upload variables are optional when `--skip-upload` is used.
 
-### 🔧 Tool Management
+- `ACCUKNOX_ENDPOINT`: Control plane URL for result upload
+- `ACCUKNOX_LABEL`: Label used to associate uploaded results
+- `ACCUKNOX_TOKEN`: Bearer token for upload
+- `ACCUKNOX_PROJECT_NAME`: Project name used for SBOM uploads
+- `ACCUKNOX_PROJECT`: Legacy fallback for project name
+- `DEBUG`: Set to `TRUE` for verbose debug logs
+- `SOFT_FAIL`: Set to `TRUE` to enable soft-fail by default
+- `KEEP_RESULTS`: Set to `TRUE` to keep result files after scan completion
+- `SCAN_IMAGE`: Override the scanner image used in container mode
+- `CODEASSURE_IMAGE`: Override the AI analysis image used by SAST AI analysis
 
-#### Install or Update Tools
+## Tool Management
+
+Install all supported local tools:
 
 ```bash
 accuknox-aspm-scanner tool install --all
 ```
 
-Or install/update specific tools:
+Install or update a specific tool:
 
 ```bash
 accuknox-aspm-scanner tool install --type iac
+accuknox-aspm-scanner tool update --type iac
 ```
 
 Supported tool types:
 
-* `sast` – Static Code Analysis
-* `sq-sast` – Static Analysis via SonarQube
-* `secret` – Secret Detection
-* `iac` – IaC Static Code Analysis
-* `container` – Container Image Scanning
-* `dast` – Dynamic Analysis
+- `iac`
+- `sast`
+- `sq-sast`
+- `secret`
+- `container`
+- `dast`
+- `codeassure`
 
-This installs the CLI into:
+User-level tool installs are placed under:
 
-```
+```bash
 ~/.local/bin/accuknox/
 ```
 
----
+## How The Scan Command Works
 
-## 🔍 Scan Workflows
-
-Each scan supports `--command`, which passes arguments **directly to the underlying scanner**.
-
-### 🏗️ Infrastructure as Code (IaC) Scan
+All scans follow this structure:
 
 ```bash
-accuknox-aspm-scanner scan iac --command "-d ."
+accuknox-aspm-scanner scan [flags-before-the-scan-name] <scan-name> --command "<scanner-args>" [flags-after-the-scan-name]
 ```
 
-### 💻 Static Application Security Testing (SAST)
+Here is what each part means:
+
+- `scan`: tells the CLI you want to run a scan
+- `flags before the scan name`: these control the overall scan run, such as upload and result handling
+- `<scan-name>`: one of `iac`, `sast`, `secret`, `container`, `dast`, or `sq-sast`
+- `flags after the scan name`: these belong only to that specific scanner
+- `--command`: required for every scan and passed to the underlying scanner
+
+Simple rule:
+
+- If a flag is written before `iac`, `sast`, `secret`, `container`, `dast`, or `sq-sast`, it affects the overall scan behavior
+- If a flag is written after the scan name, it affects only that scanner
+
+Example:
 
 ```bash
-accuknox-aspm-scanner scan sast --command "scan ."
+accuknox-aspm-scanner scan --skip-upload --keep-results iac --command "-d ." --container-mode
 ```
 
-### 🔒 Secret Scanning
+In that example:
 
-```bash
-accuknox-aspm-scanner scan secret --command "git file://." --container-mode
-```
+- `--skip-upload` and `--keep-results` are flags before the scan name, so they control upload and file retention
+- `iac` is the scan name
+- `--command` and `--container-mode` come after `iac`, so they apply only to the IaC scanner
 
-### 🐳 Container Image Scanning
+Important:
 
-```bash
-accuknox-aspm-scanner scan container --command "--image nginx:latest"
-```
+- `--command` is required for every scan type
+- Use `--skip-upload` if you do not want to upload results
+- Use `--keep-results` if you want to keep the generated artifact files
+- Some output/report flags passed inside `--command` are normalized by the CLI so it can collect results consistently
 
-### 🌐 Dynamic Application Security Testing (DAST)
+Common flags used before the scan name:
 
-```bash
-accuknox-aspm-scanner scan dast --command ""zap-baseline.py -t http://example.com/ -I"
-```
+- `--endpoint`
+- `--label`
+- `--token`
+- `--project-name`
+- `--skip-upload`
+- `--keep-results`
+- `--softfail`
 
-### 🧠 SonarQube SAST Scan
+If you do not use `--skip-upload`, you must provide:
 
-```bash
-accuknox-aspm-scanner scan sq-sast --command "-Dsonar.projectKey='<PROJECT KEY>' -Dsonar.host.url=<HOST URL> -Dsonar.token=<TOKEN> -Dsonar.organization=<ORG ID>"
-```
+- `ACCUKNOX_ENDPOINT` or `--endpoint`
+- `ACCUKNOX_LABEL` or `--label`
+- `ACCUKNOX_TOKEN` or `--token`
 
----
+You can provide upload settings in either style:
 
-## 🔁 Common Options
-
-| Flag                           | Description                             |
-| ------------------------------ | --------------------------------------- |
-| `--endpoint`                   | Control Plane URL (overrides env var)   |
-| `--label`                      | Label or project name                   |
-| `--token`                      | Authentication token                    |
-| `--skip-upload`                | Skip uploading results to Control Plane |
-| `--softfail`                   | Do not break CI/CD pipeline on findings |
-| `--container-mode`             | Run scanner inside a container          |
-
----
-
-## 🧩 Example: Full End-to-End Run
+Using environment variables:
 
 ```bash
 ACCUKNOX_ENDPOINT=cspm.accuknox.com \
 ACCUKNOX_LABEL=POC \
 ACCUKNOX_TOKEN=abcd1234 \
-accuknox-aspm-scanner scan sast \
-  --command "scan ." \
-  --softfail
+accuknox-aspm-scanner scan iac --command "-d ." --container-mode
 ```
 
----
-
-## 🧱 Pre-Commit Integration
-
-You can easily integrate **AccuKnox Secret Scan** into your development workflow using the [`pre-commit`](https://pre-commit.com) framework.
+Using flags before the scan name:
 
 ```bash
-pip install pre-commit && accuknox-aspm-scanner pre-commit install
+accuknox-aspm-scanner scan --endpoint cspm.accuknox.com --label POC --token abcd1234 iac --command "-d ." --container-mode
 ```
 
-This automatically installs a `pre-commit` hook at:
+## Scan Reference
 
+### IaC Scan
+
+Use for Checkov-based IaC scanning.
+
+Required:
+
+- `--command`
+
+Flags used after `iac`:
+
+- `--container-mode`
+- `--repo-url`
+- `--repo-branch`
+
+Typical `--command` value:
+
+```bash
+-d .
 ```
-.git/hooks/pre-commit
-```
-
----
-
-## 🧩 On-Premise & Air-Gapped Setup
-
-In a fully offline/on-premise environment:
-
-1. **Install** the precompiled `.deb.gz` or tarball
-2. **Disable** container mode if installed natively
-    3. For container mode **Set** `SCAN_IMAGE` to use internal registry images
 
 Example:
 
 ```bash
-export SCAN_IMAGE=registry.local/semgrep:latest
+accuknox-aspm-scanner scan --skip-upload --keep-results iac --command "-d ."
+```
+
+Container mode with AccuKnox upload:
+
+```bash
+ACCUKNOX_ENDPOINT=cspm.accuknox.com \
+ACCUKNOX_LABEL=POC \
+ACCUKNOX_TOKEN=abcd1234 \
 accuknox-aspm-scanner scan iac --command "-d ." --container-mode
 ```
 
----
+### SAST Scan
 
-## 🧪 Debugging
+Use for OpenGrep/SAST scanning.
+
+Required:
+
+- `--command`
+
+Flags used after `sast`:
+
+- `--container-mode`
+- `--severity`
+- `--aiscan-severity`
+- `--repo-url`
+- `--commit-ref`
+- `--commit-sha`
+- `--pipeline-id`
+- `--job-url`
+- `--ai-analysis`
+- `--codeassure-config`
+
+Typical `--command` value:
+
+```bash
+scan .
+```
+
+Basic example:
+
+```bash
+accuknox-aspm-scanner scan --skip-upload --keep-results sast --command "scan ."
+```
+
+With AI analysis:
+
+```bash
+accuknox-aspm-scanner scan --skip-upload --keep-results sast --command "scan ." --ai-analysis --aiscan-severity "HIGH,CRITICAL"
+```
+
+Container mode with AccuKnox upload:
+
+```bash
+ACCUKNOX_ENDPOINT=cspm.accuknox.com \
+ACCUKNOX_LABEL=POC \
+ACCUKNOX_TOKEN=abcd1234 \
+accuknox-aspm-scanner scan sast --command "scan ." --container-mode
+```
+
+### Secret Scan
+
+Use for TruffleHog-based secret scanning.
+
+Required:
+
+- `--command`
+
+Flags used after `secret`:
+
+- `--container-mode`
+
+Typical `--command` value:
+
+```bash
+git file://.
+```
+
+Example:
+
+```bash
+accuknox-aspm-scanner scan --skip-upload --keep-results secret --command "git file://." --container-mode
+```
+
+Container mode with AccuKnox upload:
+
+```bash
+ACCUKNOX_ENDPOINT=cspm.accuknox.com \
+ACCUKNOX_LABEL=POC \
+ACCUKNOX_TOKEN=abcd1234 \
+accuknox-aspm-scanner scan secret --command "git file://." --container-mode
+```
+
+### Container Scan
+
+Use for Trivy-based container image scanning.
+
+Required:
+
+- `--command`
+
+Flags used after `container`:
+
+- `--container-mode`
+- `--generate-sbom`
+
+Typical `--command` value:
+
+```bash
+image nginx:latest
+```
+
+Example:
+
+```bash
+accuknox-aspm-scanner scan --skip-upload --keep-results container --command "image nginx:latest" --container-mode
+```
+
+SBOM example:
+
+```bash
+accuknox-aspm-scanner scan --skip-upload --keep-results --project-name demo-project container --command "image nginx:latest" --generate-sbom --container-mode
+```
+
+Container mode with AccuKnox upload:
+
+```bash
+ACCUKNOX_ENDPOINT=cspm.accuknox.com \
+ACCUKNOX_LABEL=POC \
+ACCUKNOX_TOKEN=abcd1234 \
+accuknox-aspm-scanner scan container --command "image nginx:latest" --container-mode
+```
+
+### DAST Scan
+
+Use for OWASP ZAP-based scanning.
+
+Required:
+
+- `--command`
+
+Flags used after `dast`:
+
+- `--severity-threshold`
+- `--container-mode`
+
+Typical `--command` value:
+
+```bash
+zap-baseline.py -t http://example.com/ -I
+```
+
+Recommended example:
+
+```bash
+accuknox-aspm-scanner scan --skip-upload --keep-results dast --command "zap-baseline.py -t http://example.com/ -I" --container-mode
+```
+
+Container mode with AccuKnox upload:
+
+```bash
+ACCUKNOX_ENDPOINT=cspm.accuknox.com \
+ACCUKNOX_LABEL=POC \
+ACCUKNOX_TOKEN=abcd1234 \
+accuknox-aspm-scanner scan dast --command "zap-baseline.py -t http://example.com/ -I" --container-mode
+```
+
+### SonarQube SAST Scan
+
+Use for SonarQube-based SAST plus result fetch.
+
+Required:
+
+- `--command`
+
+Flags used after `sq-sast`:
+
+- `--skip-sonar-scan`
+- `--container-mode`
+- `--repo-url`
+- `--branch`
+- `--commit-sha`
+- `--pipeline-url`
+
+Typical `--command` value:
+
+```bash
+-Dsonar.projectKey=<PROJECT_KEY> -Dsonar.host.url=<HOST_URL> -Dsonar.token=<TOKEN> -Dsonar.organization=<ORG_ID>
+```
+
+Example:
+
+```bash
+accuknox-aspm-scanner scan --skip-upload --keep-results sq-sast --command "-Dsonar.projectKey=<PROJECT_KEY> -Dsonar.host.url=<HOST_URL> -Dsonar.token=<TOKEN> -Dsonar.organization=<ORG_ID>"
+```
+
+Important note:
+
+- Even with `--skip-sonar-scan`, `--command` is still required by the current parser
+
+Container mode with AccuKnox upload:
+
+```bash
+ACCUKNOX_ENDPOINT=cspm.accuknox.com \
+ACCUKNOX_LABEL=POC \
+ACCUKNOX_TOKEN=abcd1234 \
+accuknox-aspm-scanner scan sq-sast --command "-Dsonar.projectKey=<PROJECT_KEY> -Dsonar.host.url=<HOST_URL> -Dsonar.token=<TOKEN> -Dsonar.organization=<ORG_ID>" --container-mode
+```
+
+## Quickstart
+
+Local mode is the default. Install the required local tool first:
+
+```bash
+accuknox-aspm-scanner tool install --type iac
+accuknox-aspm-scanner scan --skip-upload --keep-results iac --command "-d ."
+```
+
+Upload example:
+
+```bash
+ACCUKNOX_ENDPOINT=cspm.accuknox.com \
+ACCUKNOX_LABEL=POC \
+ACCUKNOX_TOKEN=abcd1234 \
+accuknox-aspm-scanner scan --softfail sast --command "scan ."
+```
+
+## On-Prem / Air-Gapped Usage
+
+For most on-prem POCs:
+
+1. Install the CLI using the wheel or `.deb` package.
+2. Decide whether each scan will run in local mode or container mode.
+3. If upload is not available, use `--skip-upload`.
+4. If you want local artifacts, use `--keep-results`.
+5. If using container mode in a restricted environment, point `SCAN_IMAGE` to your internal registry image before each scan.
+
+Recommended on-prem pattern:
+
+```bash
+accuknox-aspm-scanner scan --skip-upload --keep-results <scan-name> --command "<scanner args>"
+```
+
+### On-prem examples
+
+IaC with mirrored Checkov image:
+
+```bash
+export SCAN_IMAGE=registry.local/bridgecrew/checkov:3.2.458
+accuknox-aspm-scanner scan --skip-upload --keep-results iac --command "-d ." --container-mode
+```
+
+Secret scan with mirrored TruffleHog image:
+
+```bash
+export SCAN_IMAGE=registry.local/trufflesecurity/trufflehog:3.90.3
+accuknox-aspm-scanner scan --skip-upload --keep-results secret --command "git file://." --container-mode
+```
+
+Container scan with mirrored Trivy image:
+
+```bash
+export SCAN_IMAGE=registry.local/accuknox/trivy:0.69.3
+accuknox-aspm-scanner scan --skip-upload --keep-results container --command "image nginx:latest" --container-mode
+```
+
+DAST with mirrored ZAP image:
+
+```bash
+export SCAN_IMAGE=registry.local/zaproxy/zap-stable:2.16.1
+accuknox-aspm-scanner scan --skip-upload --keep-results dast --command "zap-baseline.py -t http://example.com/ -I" --container-mode
+```
+
+SonarQube SAST against self-hosted SonarQube:
+
+```bash
+export SCAN_IMAGE=registry.local/sonarsource/sonar-scanner-cli:11.4
+accuknox-aspm-scanner scan --skip-upload --keep-results sq-sast --command "-Dsonar.projectKey=my-project -Dsonar.host.url=https://sonarqube.internal -Dsonar.token=$SONAR_TOKEN" --container-mode
+```
+
+### On-prem notes
+
+- `SCAN_IMAGE` is shared across scanner types, so set it per scan type
+- `CODEASSURE_IMAGE` is used only for SAST AI analysis
+- DAST is most reliable in `--container-mode`
+- Result files are deleted unless `--keep-results` is used
+- `tool install` downloads public artifacts, so fully restricted environments may need pre-staged local tools or mirrored images
+
+More detailed operational notes and workarounds are available in `docs/onprem-poc-runbook.md`.
+
+## Pre-Commit Integration
+
+Install the generated pre-commit hook:
+
+```bash
+accuknox-aspm-scanner pre-commit install
+```
+
+Remove the generated pre-commit hook:
+
+```bash
+accuknox-aspm-scanner pre-commit uninstall
+```
+
+## Debugging
 
 Enable verbose debug mode:
 
 ```bash
-DEBUG=TRUE accuknox-aspm-scanner scan iac --command "-d ."
+DEBUG=TRUE accuknox-aspm-scanner scan --skip-upload iac --command "-d ."
 ```
-
----

--- a/docs/onprem-poc-runbook.md
+++ b/docs/onprem-poc-runbook.md
@@ -1,0 +1,289 @@
+# On-Prem POC Runbook
+
+This runbook is for running `accuknox-aspm-scanner` in restricted, self-hosted, or air-gapped environments.
+
+It focuses on the current behavior of the CLI as implemented today, including limitations and practical workarounds for a POC.
+
+## Recommended POC Approach
+
+Use one of these operating models:
+
+- Local mode: install the required scanner tools first with `accuknox-aspm-scanner tool install ...`, then run scans without `--container-mode`.
+- Container mode: run scans with `--container-mode` and provide scanner images from an internal registry when needed.
+- Offline artifact collection: use `--skip-upload --keep-results` so the scan runs locally and preserves the generated result files.
+
+For most on-prem POCs:
+
+- Use `--skip-upload` unless the control plane endpoint is already reachable from the environment.
+- Use `--keep-results` so output artifacts remain available for review.
+- Prefer `--container-mode` for DAST.
+- Treat `SCAN_IMAGE` as a per-scan override, not a global environment default for all scanner types.
+
+## Prerequisites
+
+### Local mode
+
+- Python environment with the CLI installed.
+- Required scanner tools installed with `accuknox-aspm-scanner tool install --type <tool>`.
+- Linux is the best-supported local mode today.
+
+Tool locations:
+
+- User installs: `~/.local/bin/accuknox/`
+- Debian package installs: `/usr/share/accuknox-aspm-scanner/tools`
+
+### Container mode
+
+- Docker daemon access from the machine running the CLI.
+- Ability to pull scanner images from a reachable registry.
+- If using an internal registry, export `SCAN_IMAGE` or `CODEASSURE_IMAGE` before the relevant scan.
+
+### Optional upload to AccuKnox
+
+These are only required when not using `--skip-upload`:
+
+- `ACCUKNOX_ENDPOINT`
+- `ACCUKNOX_LABEL`
+- `ACCUKNOX_TOKEN`
+- `ACCUKNOX_PROJECT_NAME` for SBOM uploads
+
+## Installation Patterns
+
+### Connected environment
+
+Install the CLI from the GitHub release wheel:
+
+```bash
+pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.2/accuknox_aspm_scanner-0.14.2-py3-none-any.whl
+```
+
+### Restricted or on-prem environment
+
+Install the Debian package from the provided release artifact:
+
+```bash
+sudo dpkg -i accuknox-aspm-scanner_<version>.deb
+```
+
+### Install local scanner tools
+
+Install all local tools:
+
+```bash
+accuknox-aspm-scanner tool install --all
+```
+
+Install a specific local tool:
+
+```bash
+accuknox-aspm-scanner tool install --type iac
+```
+
+Update a specific local tool:
+
+```bash
+accuknox-aspm-scanner tool update --type iac
+```
+
+Supported tool types:
+
+- `iac`
+- `sast`
+- `sq-sast`
+- `secret`
+- `container`
+- `dast`
+- `codeassure`
+
+## Common Environment Variables
+
+- `DEBUG=TRUE`: enable verbose logs.
+- `SOFT_FAIL=TRUE`: make soft-fail the default.
+- `KEEP_RESULTS=TRUE`: preserve result files after completion.
+- `SCAN_IMAGE=<image>`: override the current scanner image in container mode.
+- `CODEASSURE_IMAGE=<image>`: override the SAST AI analysis image.
+
+Important: `SCAN_IMAGE` is shared across multiple scanner implementations. Set it only for the scan you are about to run, then unset or replace it before another scan type.
+
+## Copy-Paste POC Commands
+
+### IaC scan with mirrored Checkov image
+
+```bash
+export SCAN_IMAGE=registry.local/bridgecrew/checkov:3.2.458
+accuknox-aspm-scanner scan --skip-upload --keep-results iac --command "-d ." --container-mode
+```
+
+### SAST scan with local tool install
+
+```bash
+accuknox-aspm-scanner tool install --type sast
+accuknox-aspm-scanner scan --skip-upload --keep-results sast --command "scan ."
+```
+
+### Secret scan with mirrored TruffleHog image
+
+```bash
+export SCAN_IMAGE=registry.local/trufflesecurity/trufflehog:3.90.3
+accuknox-aspm-scanner scan --skip-upload --keep-results secret --command "git file://." --container-mode
+```
+
+### Container scan with mirrored Trivy image
+
+```bash
+export SCAN_IMAGE=registry.local/accuknox/trivy:0.69.3
+accuknox-aspm-scanner scan --skip-upload --keep-results container --command "image nginx:latest" --container-mode
+```
+
+### DAST scan with mirrored ZAP image
+
+```bash
+export SCAN_IMAGE=registry.local/zaproxy/zap-stable:2.16.1
+accuknox-aspm-scanner scan --skip-upload --keep-results dast --command "zap-baseline.py -t http://example.com/ -I" --container-mode
+```
+
+### SonarQube SAST scan against self-hosted SonarQube
+
+```bash
+export SCAN_IMAGE=registry.local/sonarsource/sonar-scanner-cli:11.4
+accuknox-aspm-scanner scan --skip-upload --keep-results sq-sast --command "-Dsonar.projectKey=my-project -Dsonar.host.url=https://sonarqube.internal -Dsonar.token=$SONAR_TOKEN" --container-mode
+```
+
+### Upload to AccuKnox when the endpoint is reachable
+
+```bash
+ACCUKNOX_ENDPOINT=cspm.accuknox.com \
+ACCUKNOX_LABEL=POC \
+ACCUKNOX_TOKEN=abcd1234 \
+accuknox-aspm-scanner scan --softfail sast --command "scan ."
+```
+
+## Result Files And Retention
+
+The CLI writes scan outputs to fixed filenames so it can upload them consistently. Common result files include:
+
+- IaC: `results_json.json`
+- SAST: `results.json`
+- Secret: `results.jsonl`
+- Container: `results.json`
+- DAST: `results.json`
+
+Operational note:
+
+- If you upload results, files are deleted after upload unless `--keep-results` is set.
+- If you use `--skip-upload`, files are still deleted unless `--keep-results` is set.
+- Some scanners normalize output-related flags inside `--command`, so do not rely on custom output filenames or report flags being preserved.
+
+For POC work, prefer:
+
+```bash
+accuknox-aspm-scanner scan --skip-upload --keep-results <scan-name> --command "<scanner args>"
+```
+
+## Troubleshooting
+
+### Upload configuration errors
+
+If upload is enabled, the CLI requires `ACCUKNOX_ENDPOINT`, `ACCUKNOX_LABEL`, and `ACCUKNOX_TOKEN` unless those are passed as flags before the scan name.
+
+Workaround:
+
+- Add `--skip-upload` for standalone testing.
+- Or export the required environment variables before running the scan.
+
+### Tool not found in local mode
+
+If a local scan fails because the tool is missing:
+
+- Run `accuknox-aspm-scanner tool install --type <tool>`
+- Or switch to `--container-mode`
+
+### Result files disappeared
+
+The CLI deletes result files by default.
+
+Workaround:
+
+- Add `--keep-results`
+- Or set `KEEP_RESULTS=TRUE`
+
+### Docker access issues
+
+Container mode requires a working Docker daemon and image pull access.
+
+Workaround:
+
+- Verify `docker run` works from the same host account.
+- Mirror the required images into an internal registry.
+- Export `SCAN_IMAGE` to the internal image before running the scan.
+
+## Current Limitations And Workarounds
+
+### `sq-sast --skip-sonar-scan` still requires `--command`
+
+The parser currently requires `--command` even when `--skip-sonar-scan` is used.
+
+Workaround:
+
+- Still provide Sonar metadata in `--command`, especially `-Dsonar.projectKey`, `-Dsonar.host.url`, and `-Dsonar.token`, so the fetcher can retrieve results.
+
+Example:
+
+```bash
+accuknox-aspm-scanner scan --skip-upload sq-sast --skip-sonar-scan --command "-Dsonar.projectKey=my-project -Dsonar.host.url=https://sonarqube.internal -Dsonar.token=$SONAR_TOKEN"
+```
+
+### DAST local mode is partial
+
+The current DAST implementation does not fully support local execution for `zap-baseline.py` and `zap-full-scan.py`.
+
+Workaround:
+
+- Use `--container-mode` for DAST POC runs.
+
+### Local tool installation is not air-gap friendly by default
+
+`tool install` downloads artifacts directly from public sources. That means fully restricted environments need either mirrored sources or pre-provisioned tools.
+
+Workaround:
+
+- Use the Debian package where possible.
+- Pre-stage the required tools into the expected install path.
+- Prefer mirrored container images for scans that can run in container mode.
+
+### Windows native local mode is incomplete
+
+Windows local tool downloads are incomplete, and non-container local mode is explicitly not supported.
+
+Workaround:
+
+- Use Linux for local-mode POC testing.
+- Use container mode where possible.
+
+### Upload TLS and enterprise network support are limited
+
+The current upload path disables SSL verification and does not provide first-class flags for custom CA bundles, proxy settings, or mTLS.
+
+Workaround:
+
+- Prefer `--skip-upload` in isolated environments.
+- If upload is required, validate control-plane connectivity early in the POC.
+- Document any proxy or CA requirements externally for the environment because the CLI does not currently expose dedicated knobs for them.
+
+### `SCAN_IMAGE` is shared across scanner types
+
+One `SCAN_IMAGE` value does not safely cover all scanner families.
+
+Workaround:
+
+- Export a scanner-specific `SCAN_IMAGE` immediately before each container-mode command.
+- Unset or replace it before switching scan types.
+
+## POC Checklist
+
+- Install the CLI using the wheel or Debian package.
+- Decide whether each scan will run in local mode or container mode.
+- Mirror required container images if the environment is restricted.
+- Use `--skip-upload --keep-results` for early validation.
+- Validate one scan from each required category before the demo.
+- Test upload separately if the control plane will be part of the POC.

--- a/docs/onprem-setup-guide.md
+++ b/docs/onprem-setup-guide.md
@@ -1,10 +1,10 @@
-# On-Prem POC Runbook
+# On-Prem Setup Guide
 
-This runbook is for running `accuknox-aspm-scanner` in restricted, self-hosted, or air-gapped environments.
+This guide is for running `accuknox-aspm-scanner` in restricted, self-hosted, or air-gapped environments.
 
-It focuses on the current behavior of the CLI as implemented today, including limitations and practical workarounds for a POC.
+It focuses on the current behavior of the CLI as implemented today, including limitations and practical workarounds for on-prem setups.
 
-## Recommended POC Approach
+## Recommended Approach
 
 Use one of these operating models:
 
@@ -12,7 +12,7 @@ Use one of these operating models:
 - Container mode: run scans with `--container-mode` and provide scanner images from an internal registry when needed.
 - Offline artifact collection: use `--skip-upload --keep-results` so the scan runs locally and preserves the generated result files.
 
-For most on-prem POCs:
+For most on-prem setups:
 
 - Use `--skip-upload` unless the control plane endpoint is already reachable from the environment.
 - Use `--keep-results` so output artifacts remain available for review.
@@ -105,7 +105,7 @@ Supported tool types:
 
 Important: `SCAN_IMAGE` is shared across multiple scanner implementations. Set it only for the scan you are about to run, then unset or replace it before another scan type.
 
-## Copy-Paste POC Commands
+## Copy-Paste Commands
 
 ### IaC scan with mirrored Checkov image
 
@@ -153,7 +153,7 @@ accuknox-aspm-scanner scan --skip-upload --keep-results sq-sast --command "-Dson
 
 ```bash
 ACCUKNOX_ENDPOINT=cspm.accuknox.com \
-ACCUKNOX_LABEL=POC \
+ACCUKNOX_LABEL=onprem \
 ACCUKNOX_TOKEN=abcd1234 \
 accuknox-aspm-scanner scan --softfail sast --command "scan ."
 ```
@@ -174,7 +174,7 @@ Operational note:
 - If you use `--skip-upload`, files are still deleted unless `--keep-results` is set.
 - Some scanners normalize output-related flags inside `--command`, so do not rely on custom output filenames or report flags being preserved.
 
-For POC work, prefer:
+For on-prem validation, prefer:
 
 ```bash
 accuknox-aspm-scanner scan --skip-upload --keep-results <scan-name> --command "<scanner args>"
@@ -239,7 +239,7 @@ The current DAST implementation does not fully support local execution for `zap-
 
 Workaround:
 
-- Use `--container-mode` for DAST POC runs.
+- Use `--container-mode` for DAST runs.
 
 ### Local tool installation is not air-gap friendly by default
 
@@ -257,7 +257,7 @@ Windows local tool downloads are incomplete, and non-container local mode is exp
 
 Workaround:
 
-- Use Linux for local-mode POC testing.
+- Use Linux for local-mode testing.
 - Use container mode where possible.
 
 ### Upload TLS and enterprise network support are limited
@@ -267,7 +267,7 @@ The current upload path disables SSL verification and does not provide first-cla
 Workaround:
 
 - Prefer `--skip-upload` in isolated environments.
-- If upload is required, validate control-plane connectivity early in the POC.
+- If upload is required, validate control-plane connectivity early.
 - Document any proxy or CA requirements externally for the environment because the CLI does not currently expose dedicated knobs for them.
 
 ### `SCAN_IMAGE` is shared across scanner types
@@ -279,11 +279,11 @@ Workaround:
 - Export a scanner-specific `SCAN_IMAGE` immediately before each container-mode command.
 - Unset or replace it before switching scan types.
 
-## POC Checklist
+## Setup Checklist
 
 - Install the CLI using the wheel or Debian package.
 - Decide whether each scan will run in local mode or container mode.
 - Mirror required container images if the environment is restricted.
 - Use `--skip-upload --keep-results` for early validation.
-- Validate one scan from each required category before the demo.
-- Test upload separately if the control plane will be part of the POC.
+- Validate one scan from each required category before production use.
+- Test upload separately if the control plane will be part of the setup.


### PR DESCRIPTION
## Summary

- fix incorrect README examples and align documented commands with the current CLI behavior
- clarify how the `scan` command is structured, including common scan flags vs scanner-specific flags
- add simple per-scan examples for IaC, SAST, Secret, Container, DAST, and SQ-SAST, including container-mode upload examples
- improve on-prem and air-gapped guidance in the README and add a detailed setup guide in `docs/onprem-setup-guide.md`

## What changed

- corrected install wording for the GitHub release wheel and `.deb` package
- fixed incorrect or confusing examples such as:
  - `--softfail` placement
  - container scan command format
  - DAST command quoting
- clarified how to read the `scan` command by explaining:
  - common flags used before the scan name
  - scanner-specific flags used after the scan name
- removed `ACCUKNOX_TENANT` from the documented environment variable list to keep the README simpler
- documented `KEEP_RESULTS`, `SCAN_IMAGE`, `CODEASSURE_IMAGE`, and other important settings more clearly
- added a help section showing how to discover commands and flags from the CLI
- added on-prem examples directly in the README for easier usage


## Notes

- this PR changes documentation only
- no CLI behavior was modified