### PR TITLE
Add filesystem SBOM support for container scans

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          # Build on the oldest common target to avoid glibc mismatches on customer hosts.
+          # Customers reported GLIBC_2.38 is required by the binary, but Ubuntu 22.04 ships an older glibc.
+          - os: ubuntu-22.04
             name: linux
             suffix: ''
             ext: ''
@@ -97,7 +99,7 @@ jobs:
             dist/accuknox-aspm-scanner${{ matrix.ext }}
 
       - name: Upload Ubuntu Native Binary Artifact
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         uses: actions/upload-artifact@v4
         with:
           name: native-binary-linux
@@ -105,7 +107,7 @@ jobs:
           path: dist/accuknox-aspm-scanner
 
       - name: Flag Ubuntu completion
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         id: set-output-ubuntu
         run: echo "ready=true" >> $GITHUB_OUTPUT
 

--- a/aspm_cli/commands/scan_command.py
+++ b/aspm_cli/commands/scan_command.py
@@ -10,6 +10,7 @@ from aspm_cli.utils.spinner import Spinner
 from aspm_cli.utils.config import ConfigValidator
 from aspm_cli.utils.common import upload_results, handle_failure, ALLOWED_SCAN_TYPES
 from aspm_cli.utils.git_info import GitInfo
+from aspm_cli.utils.sbom import derive_sbom_classifier, resolve_project_name
 
 class ScanCommand(BaseCommand):
     help_text = f"Run a security scan (e.g. {', '.join(ALLOWED_SCAN_TYPES)})"
@@ -48,8 +49,7 @@ class ScanCommand(BaseCommand):
                 "accuknox_label": args.label or os.getenv("ACCUKNOX_LABEL"),
                 "accuknox_token": args.token or os.getenv("ACCUKNOX_TOKEN"),
                 "accuknox_tenant": args.tenant or os.getenv("ACCUKNOX_TENANT"),
-                "accuknox_project_name": args.project_name
-                or os.getenv("ACCUKNOX_PROJECT"),
+                "accuknox_project_name": resolve_project_name(args.project_name),
             }
 
             # Get the correct scanner strategy from the registry
@@ -85,6 +85,9 @@ class ScanCommand(BaseCommand):
                 # If this is an SBOM upload, enrich the SBOM file with project_name and classifier
                 if is_sbom_upload:
                     project_name = accuknox_config.get("accuknox_project_name")
+                    project_classifier = derive_sbom_classifier(
+                        getattr(args, "command", "") or ""
+                    )
                     try:
                         with open(result_file, "r", encoding="utf-8") as f:
                             data = json.load(f)
@@ -92,7 +95,7 @@ class ScanCommand(BaseCommand):
                         if isinstance(data, dict):
                             if project_name:
                                 data["project_name"] = project_name
-                            data["project_classifier"] = "container"
+                            data["project_classifier"] = project_classifier
 
                             with open(result_file, "w", encoding="utf-8") as f:
                                 json.dump(data, f, indent=2)

--- a/aspm_cli/commands/scan_command.py
+++ b/aspm_cli/commands/scan_command.py
@@ -10,7 +10,7 @@ from aspm_cli.utils.spinner import Spinner
 from aspm_cli.utils.config import ConfigValidator
 from aspm_cli.utils.common import upload_results, handle_failure, ALLOWED_SCAN_TYPES
 from aspm_cli.utils.git_info import GitInfo
-from aspm_cli.utils.sbom import derive_sbom_classifier, resolve_project_name
+from aspm_cli.utils.sbom import derive_sbom_classifier, enrich_sbom_payload, resolve_project_name
 
 class ScanCommand(BaseCommand):
     help_text = f"Run a security scan (e.g. {', '.join(ALLOWED_SCAN_TYPES)})"
@@ -85,23 +85,25 @@ class ScanCommand(BaseCommand):
                 # If this is an SBOM upload, enrich the SBOM file with project_name and classifier
                 if is_sbom_upload:
                     project_name = accuknox_config.get("accuknox_project_name")
-                    project_classifier = derive_sbom_classifier(
-                        getattr(args, "command", "") or ""
-                    )
+                    scan_command = getattr(args, "command", "") or ""
+                    project_classifier = derive_sbom_classifier(scan_command)
                     try:
                         with open(result_file, "r", encoding="utf-8") as f:
                             data = json.load(f)
 
                         if isinstance(data, dict):
-                            if project_name:
-                                data["project_name"] = project_name
-                            data["project_classifier"] = project_classifier
+                            enrich_sbom_payload(
+                                data,
+                                scan_command,
+                                project_name,
+                                project_classifier,
+                            )
 
                             with open(result_file, "w", encoding="utf-8") as f:
                                 json.dump(data, f, indent=2)
                     except Exception as e:
                         Logger.get_logger().debug(
-                            f"Failed to enrich SBOM results.json with project_name/classifier: {e}"
+                            f"Failed to enrich SBOM results.json: {e}"
                         )
 
                 # Upload if not skipping

--- a/aspm_cli/scan/container.py
+++ b/aspm_cli/scan/container.py
@@ -1,6 +1,7 @@
 import subprocess
 import json
 import os
+import re
 import shlex
 from aspm_cli.tool.manager import ToolManager
 from aspm_cli.utils.logger import Logger
@@ -27,7 +28,7 @@ class ContainerScanner:
             scan_cmd = self._build_scan_command(sanitized_args)
 
             log_msg = (
-                "Running Trivy SBOM scan"
+                "Running container SBOM scan"
                 if self.generate_sbom
                 else "Scanning container image"
             )
@@ -35,13 +36,23 @@ class ContainerScanner:
             result = subprocess.run(scan_cmd, capture_output=True, text=True)
 
             if result.stdout:
-                sanitized_stdout = result.stdout.replace("trivy", "[scanner]")
+                sanitized_stdout = re.sub(
+                    r"trivy|aquasecurity|aqua security",
+                    "[scanner]",
+                    result.stdout,
+                    flags=re.IGNORECASE,
+                )
                 Logger.get_logger().debug(sanitized_stdout)
                 if("--help" in self.command):
                     Logger.log_with_color('INFO', sanitized_stdout, Fore.WHITE)
                     return config.PASS_RETURN_CODE, None
             if result.stderr:
-                sanitized_stderr = result.stderr.replace("trivy", "[scanner]")
+                sanitized_stderr = re.sub(
+                    r"trivy|aquasecurity|aqua security",
+                    "[scanner]",
+                    result.stderr,
+                    flags=re.IGNORECASE,
+                )
                 Logger.get_logger().error(sanitized_stderr)
 
             if self.generate_sbom:

--- a/aspm_cli/scan/container.py
+++ b/aspm_cli/scan/container.py
@@ -6,6 +6,7 @@ from aspm_cli.tool.manager import ToolManager
 from aspm_cli.utils.logger import Logger
 from aspm_cli.utils import docker_pull
 from aspm_cli.utils import config
+from aspm_cli.utils.sbom import normalize_sbom_args_for_docker
 from colorama import Fore
 
 class ContainerScanner:
@@ -25,7 +26,12 @@ class ContainerScanner:
             severity_threshold, sanitized_args = self._build_container_scan_args()
             scan_cmd = self._build_scan_command(sanitized_args)
 
-            Logger.get_logger().debug(f"Scanning container image: {' '.join(scan_cmd)}")
+            log_msg = (
+                "Running Trivy SBOM scan"
+                if self.generate_sbom
+                else "Scanning container image"
+            )
+            Logger.get_logger().debug(f"{log_msg}: {' '.join(scan_cmd)}")
             result = subprocess.run(scan_cmd, capture_output=True, text=True)
 
             if result.stdout:
@@ -79,6 +85,10 @@ class ContainerScanner:
                 i += 1
             # Force cyclonedx format and JSON output
             sanitized_args.extend(["-f", "cyclonedx", "-o", self.result_file])
+            if self.container_mode:
+                sanitized_args = normalize_sbom_args_for_docker(
+                    self.command or "", sanitized_args
+                )
             return None, sanitized_args
 
         # Flags that take a value and should be removed.

--- a/aspm_cli/scanners/container_scanner.py
+++ b/aspm_cli/scanners/container_scanner.py
@@ -12,7 +12,10 @@ class ContainerScanner(BaseScanner):
             "--command",
             type=str,
             required=True,
-            help="Arguments to pass to the container scanner (e.g., 'image nginx:latest')"
+            help=(
+                "Trivy arguments (e.g. 'image nginx:latest' for image SBOM/vuln scan; "
+                "'filesystem .' for repo SBOM with --generate-sbom)"
+            )
         )
         parser.add_argument(
             "--container-mode",
@@ -26,7 +29,11 @@ class ContainerScanner(BaseScanner):
         )
 
     def validate_config(self, args: argparse.Namespace, validator: ConfigValidator):
-        validator.validate_container_scan(args.command, args.container_mode)
+        validator.validate_container_scan(
+            args.command,
+            args.container_mode,
+            generate_sbom=getattr(args, "generate_sbom", False),
+        )
 
     def run_scan(self, args: argparse.Namespace) -> tuple[int, str]:
         # Instantiate and run the original scanner logic

--- a/aspm_cli/scanners/container_scanner.py
+++ b/aspm_cli/scanners/container_scanner.py
@@ -4,7 +4,7 @@ from aspm_cli.utils.config import ConfigValidator
 from aspm_cli.scan.container import ContainerScanner as OriginalContainerScanner
 
 class ContainerScanner(BaseScanner):
-    help_text = "Run a container image scan using Trivy"
+    help_text = "Run a container image or filesystem SBOM scan"
     data_type_identifier = "TR"
 
     def add_arguments(self, parser: argparse.ArgumentParser):
@@ -13,7 +13,7 @@ class ContainerScanner(BaseScanner):
             type=str,
             required=True,
             help=(
-                "Trivy arguments (e.g. 'image nginx:latest' for image SBOM/vuln scan; "
+                "Scanner arguments (e.g. 'image nginx:latest' for image SBOM/vuln scan; "
                 "'filesystem .' for repo SBOM with --generate-sbom)"
             )
         )

--- a/aspm_cli/utils/config.py
+++ b/aspm_cli/utils/config.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, Field, ValidationError, field_validator, model_v
 from typing import Optional, Literal
 from aspm_cli.utils.logger import Logger
 from aspm_cli.utils.common import ALLOWED_SCAN_TYPES
+from aspm_cli.utils.sbom import validate_sbom_command
 
 # Return code constants
 PASS_RETURN_CODE = 0
@@ -159,18 +160,33 @@ class ConfigValidator:
             Logger.get_logger().debug(f"Secret scan configuration error: {concise_msg}")
             raise ValueError(concise_msg)
 
-    def validate_container_scan(self, command: str, container_mode: bool):
+    def validate_container_scan(
+        self,
+        command: str,
+        container_mode: bool,
+        generate_sbom: bool = False,
+    ):
         class ContainerScanConfig(BaseModel):
             command: str = Field(..., min_length=1, description="Command arguments for Container scanner")
             container_mode: bool
 
         try:
             ContainerScanConfig(command=command, container_mode=container_mode)
-            self._log_validation_success("Container")
         except ValidationError as e:
             concise_msg = _format_validation_error(e)
             Logger.get_logger().debug(f"Container scan configuration error: {concise_msg}")
             raise ValueError(concise_msg)
+
+        if generate_sbom:
+            validate_sbom_command(command)
+            if not self.skip_upload and not self.accuknox_config.accuknox_project_name:
+                raise ValueError(
+                    "AccuKnox project name is required for SBOM uploads. "
+                    "Provide --project-name or set ACCUKNOX_PROJECT_NAME (or legacy ACCUKNOX_PROJECT), "
+                    "or use --skip-upload if you only need a local SBOM file."
+                )
+
+        self._log_validation_success("Container")
 
     def validate_sast_scan(self, command: str, container_mode: bool, severity: str, repo_url: Optional[str], commit_ref: Optional[str], commit_sha: Optional[str], pipeline_id: Optional[str], job_url: Optional[str]):
         class SASTScanConfig(BaseModel):

--- a/aspm_cli/utils/sbom.py
+++ b/aspm_cli/utils/sbom.py
@@ -1,10 +1,12 @@
 import os
 import shlex
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 SBOM_ALLOWED_SUBCOMMANDS = frozenset({"image", "rootfs", "filesystem", "fs"})
 FILESYSTEM_SUBCOMMANDS = frozenset({"filesystem", "fs"})
 DOCKER_WORKDIR = "/workdir"
+ACCUKNOX_SCANNER_TOOL_NAME = "accuknox-container-scanner"
+ACCUKNOX_SCANNER_VENDOR = "AccuKnox"
 
 
 def parse_trivy_subcommand(command: str) -> Optional[str]:
@@ -44,13 +46,141 @@ def resolve_project_name(cli_value: Optional[str] = None) -> Optional[str]:
     return None
 
 
+def scan_target_from_command(command: str) -> Optional[str]:
+    """Return the scan target path argument after the subcommand, if present."""
+    if not command:
+        return None
+    args = shlex.split(command)
+    subcommand = parse_trivy_subcommand(command)
+    if not subcommand:
+        return None
+    try:
+        idx = args.index(subcommand)
+        if idx + 1 < len(args):
+            return args[idx + 1]
+    except ValueError:
+        return None
+    return None
+
+
+def derive_filesystem_component_display_name(
+    command: str,
+    cwd: Optional[str] = None,
+) -> str:
+    """
+    Human-readable BOM root name from host cwd and --command target (e.g. repo or repo/utils).
+    """
+    cwd = cwd or os.getcwd()
+    repo = os.path.basename(os.path.abspath(cwd))
+    target = scan_target_from_command(command)
+    if not target or target in (".", ""):
+        return repo
+    if target == DOCKER_WORKDIR:
+        return repo
+    if target.startswith(f"{DOCKER_WORKDIR}/"):
+        subpath = target[len(DOCKER_WORKDIR) + 1 :].strip("/")
+    elif target.startswith("./"):
+        subpath = target[2:].strip("/")
+    elif _is_relative_scan_path(target):
+        subpath = target.strip("/")
+    else:
+        subpath = os.path.basename(target.rstrip(os.sep))
+    if subpath:
+        return f"{repo}/{subpath}"
+    return repo
+
+
+def _should_rewrite_component_name(name: str) -> bool:
+    if not name:
+        return True
+    if name in (".", ""):
+        return True
+    if name == DOCKER_WORKDIR or name.startswith(f"{DOCKER_WORKDIR}/"):
+        return True
+    return False
+
+
+def _sanitize_property_name(name: str) -> str:
+    if name.startswith("aquasecurity:trivy:"):
+        return "accuknox:scanner:" + name[len("aquasecurity:trivy:") :]
+    return name
+
+
+def _sanitize_properties_list(properties: Optional[List[Dict[str, Any]]]) -> None:
+    if not properties:
+        return
+    for prop in properties:
+        if isinstance(prop, dict) and "name" in prop:
+            prop["name"] = _sanitize_property_name(str(prop["name"]))
+
+
+def sanitize_scanner_branding_from_bom(data: Dict[str, Any]) -> None:
+    """Remove upstream scanner vendor/tool identifiers from CycloneDX output."""
+    metadata = data.get("metadata")
+    if not isinstance(metadata, dict):
+        return
+
+    tools = metadata.get("tools")
+    if isinstance(tools, dict):
+        tools["components"] = [
+            {
+                "type": "application",
+                "manufacturer": {"name": ACCUKNOX_SCANNER_VENDOR},
+                "name": ACCUKNOX_SCANNER_TOOL_NAME,
+            }
+        ]
+
+    component = metadata.get("component")
+    if isinstance(component, dict):
+        if component.get("group") == "aquasecurity":
+            del component["group"]
+        manufacturer = component.get("manufacturer")
+        if isinstance(manufacturer, dict):
+            mfg_name = str(manufacturer.get("name", ""))
+            if "aqua" in mfg_name.lower():
+                component["manufacturer"] = {"name": ACCUKNOX_SCANNER_VENDOR}
+        _sanitize_properties_list(component.get("properties"))
+
+    for comp in data.get("components") or []:
+        if isinstance(comp, dict):
+            _sanitize_properties_list(comp.get("properties"))
+
+
+def apply_filesystem_component_display_name(data: Dict[str, Any], command: str) -> None:
+    """Replace /workdir paths in metadata.component.name with host-relative display names."""
+    if parse_trivy_subcommand(command) not in FILESYSTEM_SUBCOMMANDS:
+        return
+    display = derive_filesystem_component_display_name(command)
+    metadata = data.get("metadata")
+    if not isinstance(metadata, dict):
+        return
+    component = metadata.get("component")
+    if isinstance(component, dict):
+        if _should_rewrite_component_name(str(component.get("name", ""))):
+            component["name"] = display
+
+
+def enrich_sbom_payload(
+    data: Dict[str, Any],
+    command: str,
+    project_name: Optional[str],
+    project_classifier: str,
+) -> None:
+    """Apply AccuKnox SBOM fields, human-readable paths, and branding sanitization."""
+    if project_name:
+        data["project_name"] = project_name
+    data["project_classifier"] = project_classifier
+    apply_filesystem_component_display_name(data, command)
+    sanitize_scanner_branding_from_bom(data)
+
+
 def validate_sbom_command(command: str) -> None:
-    """Require a supported Trivy subcommand when generating SBOM."""
+    """Require a supported container scanner subcommand when generating SBOM."""
     subcommand = parse_trivy_subcommand(command)
     if subcommand not in SBOM_ALLOWED_SUBCOMMANDS:
         raise ValueError(
-            "Invalid Trivy command for SBOM generation. "
-            f"First subcommand must be one of: {', '.join(sorted(SBOM_ALLOWED_SUBCOMMANDS))}. "
+            "Invalid command for SBOM generation. "
+            f"First argument must be one of: {', '.join(sorted(SBOM_ALLOWED_SUBCOMMANDS))}. "
             "Examples: 'image nginx:latest' (container SBOM), 'filesystem .' (application SBOM)."
         )
 

--- a/aspm_cli/utils/sbom.py
+++ b/aspm_cli/utils/sbom.py
@@ -1,0 +1,96 @@
+import os
+import shlex
+from typing import List, Optional, Tuple
+
+SBOM_ALLOWED_SUBCOMMANDS = frozenset({"image", "rootfs", "filesystem", "fs"})
+FILESYSTEM_SUBCOMMANDS = frozenset({"filesystem", "fs"})
+DOCKER_WORKDIR = "/workdir"
+
+
+def parse_trivy_subcommand(command: str) -> Optional[str]:
+    """Return the first positional Trivy subcommand, skipping leading flags."""
+    if not command:
+        return None
+    args = shlex.split(command)
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg.startswith("-"):
+            if arg in ("-f", "--format", "-o", "--output", "-s", "--severity") and i + 1 < len(args):
+                i += 2
+                continue
+            i += 1
+            continue
+        return arg
+    return None
+
+
+def derive_sbom_classifier(command: str) -> str:
+    """Map Trivy subcommand to AccuKnox project_classifier for SBOM enrichment."""
+    subcommand = parse_trivy_subcommand(command)
+    if subcommand in FILESYSTEM_SUBCOMMANDS:
+        return "application"
+    return "container"
+
+
+def resolve_project_name(cli_value: Optional[str] = None) -> Optional[str]:
+    """Resolve project name: CLI -> ACCUKNOX_PROJECT_NAME -> ACCUKNOX_PROJECT."""
+    if cli_value:
+        return cli_value
+    if "ACCUKNOX_PROJECT_NAME" in os.environ:
+        return os.environ["ACCUKNOX_PROJECT_NAME"]
+    if "ACCUKNOX_PROJECT" in os.environ:
+        return os.environ["ACCUKNOX_PROJECT"]
+    return None
+
+
+def validate_sbom_command(command: str) -> None:
+    """Require a supported Trivy subcommand when generating SBOM."""
+    subcommand = parse_trivy_subcommand(command)
+    if subcommand not in SBOM_ALLOWED_SUBCOMMANDS:
+        raise ValueError(
+            "Invalid Trivy command for SBOM generation. "
+            f"First subcommand must be one of: {', '.join(sorted(SBOM_ALLOWED_SUBCOMMANDS))}. "
+            "Examples: 'image nginx:latest' (container SBOM), 'filesystem .' (application SBOM)."
+        )
+
+
+def _is_relative_scan_path(path: str) -> bool:
+    return not path.startswith("/")
+
+
+def _normalize_path_component(path: str) -> str:
+    path = path.strip()
+    if path in (".", ""):
+        return DOCKER_WORKDIR
+    if path.startswith("./"):
+        path = path[2:]
+    return f"{DOCKER_WORKDIR}/{path}"
+
+
+def normalize_filesystem_args_for_docker(args: List[str]) -> List[str]:
+    """
+    Rewrite relative filesystem/fs scan targets to /workdir paths for container mode.
+    Leaves paths already under /workdir unchanged.
+    """
+    if not args:
+        return args
+    subcommand = args[0]
+    if subcommand not in FILESYSTEM_SUBCOMMANDS or len(args) < 2:
+        return args
+
+    result = list(args)
+    target = result[1]
+    if target.startswith(f"{DOCKER_WORKDIR}") or target == DOCKER_WORKDIR:
+        return result
+    if _is_relative_scan_path(target):
+        result[1] = _normalize_path_component(target)
+    return result
+
+
+def normalize_sbom_args_for_docker(command: str, sanitized_args: List[str]) -> List[str]:
+    """Apply docker path normalization when building SBOM args in container mode."""
+    subcommand = parse_trivy_subcommand(command)
+    if subcommand in FILESYSTEM_SUBCOMMANDS:
+        return normalize_filesystem_args_for_docker(sanitized_args)
+    return sanitized_args

--- a/docs/onprem-setup-guide.md
+++ b/docs/onprem-setup-guide.md
@@ -45,7 +45,7 @@ These are only required when not using `--skip-upload`:
 - `ACCUKNOX_ENDPOINT`
 - `ACCUKNOX_LABEL`
 - `ACCUKNOX_TOKEN`
-- `ACCUKNOX_PROJECT_NAME` for SBOM uploads
+- `ACCUKNOX_PROJECT_NAME` for SBOM uploads (legacy `ACCUKNOX_PROJECT` also accepted). Not required for container vulnerability scans.
 
 ## Installation Patterns
 
@@ -133,6 +133,16 @@ accuknox-aspm-scanner scan --skip-upload --keep-results secret --command "git fi
 ```bash
 export SCAN_IMAGE=registry.local/accuknox/trivy:0.69.3
 accuknox-aspm-scanner scan --skip-upload --keep-results container --command "image nginx:latest" --container-mode
+```
+
+### Filesystem SBOM (application classifier)
+
+Run from the repository root so the checkout is mounted at `/workdir` inside the Trivy container. Use an AccuKnox SBOM project with classifier `application` (not `container`).
+
+```bash
+export SCAN_IMAGE=registry.local/accuknox/trivy:0.69.3
+accuknox-aspm-scanner scan --skip-upload --keep-results --project-name demo-project container \
+  --command "filesystem ." --generate-sbom --container-mode
 ```
 
 ### DAST scan with mirrored ZAP image


### PR DESCRIPTION
## Summary

- Extends `container` scan with `--generate-sbom` to support Trivy `filesystem` / `fs` targets (e.g. `filesystem .`), not only `image`.
- Enriches uploaded CycloneDX with `project_classifier: application` for filesystem SBOM; image SBOM remains `container`.
- Requires `--project-name` (or `ACCUKNOX_PROJECT_NAME` / legacy `ACCUKNOX_PROJECT`) only when `--generate-sbom` and upload are enabled; container vuln scans unchanged.
- Normalizes relative filesystem paths to `/workdir/...` in `--container-mode` so Trivy sees the mounted checkout.
