### PR TITLE
feat: Phase-1 scan types (SCA, ML scan, API discovery, Gitleaks) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ![AccuKnox Logo](https://accuknox.com/wp-content/uploads/accuknox-logo-2.png)
 
-**`accuknox-aspm-scanner`** is a unified CLI for running IaC, SAST, SonarQube SAST, Secret, Container, and DAST scans in CI/CD pipelines or local developer workflows.
+**`accuknox-aspm-scanner`** is a unified CLI for Phase-1 ASPM scans: IaC, SAST, SCA, Secret, SBOM, Container, ML model scan, API discovery, SonarQube SAST, and DAST — in CI/CD pipelines or local developer workflows.
 
 It can upload results to the **AccuKnox ASPM Platform**, but it can also run in standalone mode for restricted or on-prem environments.
 
 ## Features
 
-- 🚀 One CLI for multiple scan types: IaC, SAST, SonarQube SAST, Secret, Container, and DAST
+- 🚀 One CLI for Phase-1 scan types: IaC, SAST, SCA, Secret (TruffleHog/Gitleaks), SBOM, Container, ML Scan, API Discovery, SonarQube SAST, and DAST
 - 🔄 Supports both local tools and containerized execution
 - 🔐 Optional upload to AccuKnox ASPM
 - 🧰 Works in standalone and on-prem environments
@@ -43,7 +43,10 @@ accuknox-aspm-scanner scan --help
 accuknox-aspm-scanner scan iac --help
 accuknox-aspm-scanner scan sast --help
 accuknox-aspm-scanner scan secret --help
+accuknox-aspm-scanner scan sca --help
 accuknox-aspm-scanner scan container --help
+accuknox-aspm-scanner scan ml-scan --help
+accuknox-aspm-scanner scan api-discovery --help
 accuknox-aspm-scanner scan dast --help
 accuknox-aspm-scanner scan sq-sast --help
 accuknox-aspm-scanner tool --help
@@ -70,6 +73,14 @@ AccuKnox upload variables are optional when `--skip-upload` is used.
 - `KEEP_RESULTS`: Set to `TRUE` to keep result files after scan completion
 - `SCAN_IMAGE`: Override the scanner image used in container mode
 - `CODEASSURE_IMAGE`: Override the AI analysis image used by SAST AI analysis
+- `ACCUKNOX_ENABLE_AI_SAST`: Set to `TRUE` to enable AI-SAST per repo (alternative to `--ai-analysis`)
+- `GITLEAKS_IMAGE`: Override the Gitleaks image when `--engine gitleaks`
+- `ML_SCAN_IMAGE`: Override the full ModelScan image for `ml-scan` (default: `public.ecr.aws/k9v9d5v2/accuknox/ondemand_modelscan:1.0.21`)
+- `ML_SCAN_IMAGE_REGISTRY` / `IMAGE_REGISTRY`: On-prem registry host; builds `{registry}/ondemand_modelscan:{tag}` when set
+- `ML_SCAN_IMAGE_TAG`: Tag for ondemand_modelscan (default `1.0.21`, from platform `k8s_jobs/modelscan/release.txt`)
+- `ML_SCAN_DOCKER_PLATFORM`: Docker platform for container mode (default `linux/amd64`)
+- `API_DISCOVERY_IMAGE`: Override the code2api image for `api-discovery` (alias of `SCAN_IMAGE` when set)
+- `CODE2API_IMAGE`: Default code2api scanner image when `SCAN_IMAGE` is unset
 
 ## Tool Management
 
@@ -95,6 +106,7 @@ Supported tool types:
 - `container`
 - `dast`
 - `codeassure`
+- `gitleaks`
 
 User-level tool installs are placed under:
 
@@ -114,7 +126,7 @@ Here is what each part means:
 
 - `scan`: tells the CLI you want to run a scan
 - `flags before the scan name`: these are common scan flags and work across all scan types
-- `<scan-name>`: one of `iac`, `sast`, `secret`, `container`, `dast`, or `sq-sast`
+- `<scan-name>`: one of `iac`, `sast`, `sca`, `secret`, `container`, `ml-scan`, `api-discovery`, `dast`, or `sq-sast`
 - `flags after the scan name`: these are only for the selected scanner
 - `--command`: required for every scan and passed to the underlying scanner
 
@@ -246,10 +258,16 @@ Basic example:
 accuknox-aspm-scanner scan --skip-upload --keep-results sast --command "scan ."
 ```
 
-With AI analysis:
+With AI analysis (CLI flag or per-repo env var):
 
 ```bash
 accuknox-aspm-scanner scan --skip-upload --keep-results sast --command "scan ." --ai-analysis --aiscan-severity "HIGH,CRITICAL"
+```
+
+Per-repo AI-SAST via environment variable (e.g. GitLab CI variable):
+
+```bash
+ACCUKNOX_ENABLE_AI_SAST=TRUE accuknox-aspm-scanner scan --skip-upload sast --command "scan ." --container-mode
 ```
 
 Container mode with AccuKnox upload:
@@ -263,7 +281,7 @@ accuknox-aspm-scanner scan sast --command "scan ." --container-mode
 
 ### Secret Scan
 
-Use for TruffleHog-based secret scanning.
+Use for TruffleHog or Gitleaks secret scanning.
 
 Required:
 
@@ -272,26 +290,46 @@ Required:
 Flags used after `secret`:
 
 - `--container-mode`
+- `--engine` — `trufflehog` (default) or `gitleaks`
+
+TruffleHog example:
+
+```bash
+accuknox-aspm-scanner scan --skip-upload --keep-results secret --command "filesystem ." --container-mode
+```
+
+Gitleaks example:
+
+```bash
+accuknox-aspm-scanner scan --skip-upload --keep-results secret \
+  --engine gitleaks \
+  --command "detect --source . --report-format json --report-path results.json --no-banner" \
+  --container-mode
+```
+
+### SCA Scan
+
+Use for Trivy filesystem dependency vulnerability scanning (Software Composition Analysis).
+
+Required:
+
+- `--command`
+
+Flags used after `sca`:
+
+- `--container-mode`
+- `--severity`
 
 Typical `--command` value:
 
 ```bash
-git file://.
+fs .
 ```
 
 Example:
 
 ```bash
-accuknox-aspm-scanner scan --skip-upload --keep-results secret --command "git file://." --container-mode
-```
-
-Container mode with AccuKnox upload:
-
-```bash
-ACCUKNOX_ENDPOINT=cspm.accuknox.com \
-ACCUKNOX_LABEL=POC \
-ACCUKNOX_TOKEN=abcd1234 \
-accuknox-aspm-scanner scan secret --command "git file://." --container-mode
+accuknox-aspm-scanner scan --skip-upload --keep-results sca --command "fs ." --container-mode
 ```
 
 ### Container Scan
@@ -334,6 +372,16 @@ accuknox-aspm-scanner scan --skip-upload --keep-results --project-name demo-proj
 
 SBOM upload requires `--project-name` (or `ACCUKNOX_PROJECT_NAME`). `--project-name` is not required for vulnerability scans. Legacy env `ACCUKNOX_PROJECT` is also accepted.
 
+SBOM Phase-1 capabilities:
+
+| Capability | CLI command | Upload `data_type` |
+|---|---|---|
+| Generate BOM | `container --generate-sbom` | `SBOM` |
+| Upload BOM | same + AccuKnox creds | `SBOM` |
+| Dependency vulnerabilities | `sca --command "fs ."` | `TR` (Trivy JSON; parser classifies as SCA via `ArtifactType: filesystem`) |
+
+SBOM generation includes vulnerability and license metadata in CycloneDX output (`--scanners vuln,license`).
+
 Container mode with AccuKnox upload:
 
 ```bash
@@ -342,6 +390,86 @@ ACCUKNOX_LABEL=POC \
 ACCUKNOX_TOKEN=abcd1234 \
 accuknox-aspm-scanner scan container --command "image nginx:latest" --container-mode
 ```
+
+### ML Scan
+
+Use for static ML model scanning with **ModelScan** (`modelscan==0.8.1` inside the platform **`ondemand_modelscan`** job image). The CLI discovers model files under the `-p` path (`.pkl`, `.pt`, `.pth`, `.h5`, `.keras`, `.pb`, `.ckpt`, `.npy`), runs `modelscan scan -p <file> -r json` per file, wraps results as `ondemand_modelscan`, and uploads as **`MLCHECKS`**.
+
+**Pre-release:** use `--container-mode` (recommended for CI and platform parity). Local `modelscan` on `PATH` is optional for development only; release tarballs ship in a later GA.
+
+Default container image (public mirror of platform **Modelscan Ondemand** `ondemand_modelscan:1.0.21`, `linux/amd64`):
+
+```text
+public.ecr.aws/k9v9d5v2/accuknox/ondemand_modelscan:1.0.21
+```
+
+Override with `ML_SCAN_IMAGE`, or set `IMAGE_REGISTRY` / `ML_SCAN_IMAGE_TAG` for on-prem mirrors. On Apple Silicon Macs, container mode uses `--platform linux/amd64` by default (override with `ML_SCAN_DOCKER_PLATFORM`).
+
+Flags used after `ml-scan`:
+
+- `--container-mode`
+- `--repo-url` — used for `model_id` / `model_path` metadata
+- `--commit-ref` — branch/ref in `model_path`
+- `--model-name` — optional collector name in upload payload
+- `--source-type` — default `github`
+
+Default `--command`:
+
+```bash
+scan -p . -r json
+```
+
+Example (CI — scan all models in repo checkout):
+
+```bash
+accuknox-aspm-scanner scan --skip-upload --keep-results ml-scan \
+  --repo-url "${CI_PROJECT_PATH}" \
+  --commit-ref "${CI_COMMIT_REF_NAME}" \
+  --command "scan -p . -r json" \
+  --container-mode
+```
+
+Example (single model path):
+
+```bash
+accuknox-aspm-scanner scan ml-scan \
+  --command "scan -p ./models/model.pkl -r json" \
+  --container-mode
+```
+
+### API Discovery Scan
+
+Use **code2api** for static API discovery from source (internal routes, external HTTP calls, auth hints).
+
+**Pre-release:** use `--container-mode` with the published image below. Local binary packaging (`tool install --type api-discovery`) ships in a later GA.
+
+Default container image:
+
+```text
+public.ecr.aws/k9v9d5v2/accuknox/code2api:0.1.0
+```
+
+Default `--command`:
+
+```bash
+-path . -output results.json
+```
+
+Flags used after `api-discovery`:
+
+- `--container-mode` (required for pre-release)
+- `--repo-url` (optional metadata; defaults from git)
+
+Example:
+
+```bash
+export SCAN_IMAGE=public.ecr.aws/k9v9d5v2/accuknox/code2api:0.1.0
+accuknox-aspm-scanner scan --skip-upload --keep-results api-discovery \
+  --command "-path . -output results.json" \
+  --container-mode
+```
+
+Upload uses `data_type=API`. Output is code2api JSON (`internal_apis`, `external_apis`, `summary`).
 
 ### DAST Scan
 

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ accuknox-aspm-scanner scan container --command "image nginx:latest" --container-
 
 ### ML Scan
 
-Use for static ML model scanning with **ModelScan** (`modelscan==0.8.1` inside the platform **`ondemand_modelscan`** job image). The CLI discovers model files under the `-p` path (`.pkl`, `.pt`, `.pth`, `.h5`, `.keras`, `.pb`, `.ckpt`, `.npy`), runs `modelscan scan -p <file> -r json` per file, wraps results as `ondemand_modelscan`, and uploads as **`MLCHECKS`**.
+Use for static ML model scanning with **ModelScan** (`modelscan==0.8.1` inside the platform **`ondemand_modelscan`** job image). The CLI discovers model files under the `-p` path (`.pkl`, `.pt`, `.pth`, `.h5`, `.keras`, `.pb`, `.ckpt`, `.npy`), runs `modelscan scan -p <file> -r json` per file, wraps results as `ondemand_modelscan`, and uploads with artifact **`data_type=MLC`** (routes to `ModelscanParser`; findings appear in the UI as **MLChecks**).
 
 **Pre-release:** use `--container-mode` (recommended for CI and platform parity). Local `modelscan` on `PATH` is optional for development only; release tarballs ship in a later GA.
 

--- a/README.md
+++ b/README.md
@@ -298,12 +298,12 @@ TruffleHog example:
 accuknox-aspm-scanner scan --skip-upload --keep-results secret --command "filesystem ." --container-mode
 ```
 
-Gitleaks example:
+Gitleaks example (SARIF output; upload uses `data_type=DS` → `DroopescanParser`; findings appear as **droopescan**, not in TruffleHog secret-scan filters):
 
 ```bash
 accuknox-aspm-scanner scan --skip-upload --keep-results secret \
   --engine gitleaks \
-  --command "detect --source . --report-format json --report-path results.json --no-banner" \
+  --command "detect --source . --report-format sarif --report-path results.json --no-banner" \
   --container-mode
 ```
 

--- a/aspm_cli/commands/scan_command.py
+++ b/aspm_cli/commands/scan_command.py
@@ -10,7 +10,12 @@ from aspm_cli.utils.spinner import Spinner
 from aspm_cli.utils.config import ConfigValidator
 from aspm_cli.utils.common import upload_results, handle_failure, ALLOWED_SCAN_TYPES
 from aspm_cli.utils.git_info import GitInfo
-from aspm_cli.utils.sbom import derive_sbom_classifier, enrich_sbom_payload, resolve_project_name
+from aspm_cli.utils.sbom import (
+    derive_sbom_classifier,
+    enrich_sbom_payload,
+    is_sbom_payload_empty,
+    resolve_project_name,
+)
 
 class ScanCommand(BaseCommand):
     help_text = f"Run a security scan (e.g. {', '.join(ALLOWED_SCAN_TYPES)})"
@@ -108,8 +113,32 @@ class ScanCommand(BaseCommand):
 
                 # Upload if not skipping
                 if not skip_upload:
+                    if is_sbom_upload:
+                        try:
+                            with open(result_file, "r", encoding="utf-8") as f:
+                                sbom_data = json.load(f)
+                            if is_sbom_payload_empty(sbom_data):
+                                Logger.get_logger().warning(
+                                    "SBOM output is empty or missing components; skipping upload."
+                                )
+                                if not keep_results:
+                                    os.remove(result_file)
+                                else:
+                                    Logger.get_logger().info(f"Results file kept at: {result_file}")
+                                upload_exit_code = 0
+                                Logger.get_logger().debug(
+                                    f"Scan exit_code={exit_code}, upload_exit_code={upload_exit_code}, "
+                                    f"softfail={softfail}, skip_upload={skip_upload}, keep_results={keep_results}"
+                                )
+                                handle_failure(exit_code, softfail, allow_softfail=True)
+                                return
+                        except (json.JSONDecodeError, OSError) as e:
+                            Logger.get_logger().warning(
+                                f"Could not read SBOM file for upload validation: {e}"
+                            )
+
                     # Determine data_type: SBOM for SBOM uploads, otherwise use scanner's identifier
-                    data_type = "SBOM" if is_sbom_upload else scanner.data_type_identifier
+                    data_type = "SBOM" if is_sbom_upload else scanner.get_data_type_identifier()
                     upload_exit_code = upload_results(
                         result_file,
                         accuknox_config["accuknox_endpoint"],

--- a/aspm_cli/scan/api_discovery.py
+++ b/aspm_cli/scan/api_discovery.py
@@ -1,0 +1,103 @@
+import os
+import subprocess
+
+from aspm_cli.tool.manager import ToolManager
+from aspm_cli.utils import config, docker_pull
+from aspm_cli.utils.api_discovery import (
+    DEFAULT_RESULT_FILE,
+    DOCKER_WORKDIR,
+    normalize_code2api_args,
+    normalize_code2api_args_for_docker,
+)
+from aspm_cli.utils.logger import Logger
+from aspm_cli.utils.path_safety import resolve_path_within_root
+from aspm_cli.utils.subprocess_utils import run_scan_subprocess
+from colorama import Fore
+
+CODE2API_IMAGE = os.getenv(
+    "CODE2API_IMAGE",
+    "public.ecr.aws/k9v9d5v2/accuknox/code2api:0.1.0",
+)
+
+
+class APIDiscoveryScanner:
+    result_file = DEFAULT_RESULT_FILE
+
+    def __init__(self, command, container_mode=False):
+        self.command = command
+        self.container_mode = container_mode
+        self.scan_image = os.getenv("SCAN_IMAGE", CODE2API_IMAGE)
+        self.cwd = os.getcwd()
+
+    def run(self):
+        try:
+            if self.container_mode:
+                docker_pull(self.scan_image)
+
+            args = normalize_code2api_args(self.command, self.result_file)
+            if "-version" in args:
+                cmd = self._build_scan_command(["-version"])
+                result = run_scan_subprocess(cmd)
+                if result.stdout:
+                    Logger.log_with_color("INFO", result.stdout, Fore.WHITE)
+                return config.PASS_RETURN_CODE, None
+
+            try:
+                path_idx = args.index("-path")
+                if path_idx + 1 < len(args):
+                    resolve_path_within_root(args[path_idx + 1], self.cwd)
+            except ValueError as exc:
+                Logger.get_logger().error(str(exc))
+                return config.SOMETHING_WENT_WRONG_RETURN_CODE, None
+
+            if self.container_mode:
+                args = normalize_code2api_args_for_docker(args, cwd=self.cwd)
+
+            cmd = self._build_scan_command(args)
+
+            Logger.get_logger().debug(f"Running API discovery scan: {' '.join(cmd)}")
+            result = run_scan_subprocess(cmd)
+
+            if result.stdout:
+                Logger.get_logger().debug(
+                    result.stdout.replace("code2api", "[scanner]")
+                )
+            if result.stderr:
+                Logger.get_logger().error(
+                    result.stderr.replace("code2api", "[scanner]")
+                )
+
+            if os.path.exists(self.result_file) and os.stat(self.result_file).st_size > 0:
+                return result.returncode, self.result_file
+
+            if result.returncode == 0:
+                Logger.get_logger().info(
+                    "API discovery completed with no output file (no APIs found or empty scan)."
+                )
+            return result.returncode, None
+        except subprocess.TimeoutExpired:
+            Logger.get_logger().error("API discovery scan timed out")
+            return config.SOMETHING_WENT_WRONG_RETURN_CODE, None
+        except subprocess.CalledProcessError as e:
+            Logger.get_logger().error(f"Error during API discovery scan: {e}")
+            raise
+
+    def _resolve_local_binary(self) -> str:
+        try:
+            return ToolManager.get_path("api-discovery")
+        except (ValueError, FileNotFoundError):
+            return "code2api"
+
+    def _build_scan_command(self, args):
+        if not self.container_mode:
+            return [self._resolve_local_binary(), *args]
+
+        return [
+            "docker", "run", "--rm",
+            "-v", f"{self.cwd}:{DOCKER_WORKDIR}",
+            "--workdir", DOCKER_WORKDIR,
+            self.scan_image,
+            *args,
+        ]
+
+

--- a/aspm_cli/scan/container.py
+++ b/aspm_cli/scan/container.py
@@ -7,7 +7,7 @@ from aspm_cli.tool.manager import ToolManager
 from aspm_cli.utils.logger import Logger
 from aspm_cli.utils import docker_pull
 from aspm_cli.utils import config
-from aspm_cli.utils.sbom import normalize_sbom_args_for_docker
+from aspm_cli.utils.sbom import append_sbom_scanner_flags, normalize_sbom_args_for_docker
 from colorama import Fore
 
 class ContainerScanner:
@@ -96,6 +96,7 @@ class ContainerScanner:
                 i += 1
             # Force cyclonedx format and JSON output
             sanitized_args.extend(["-f", "cyclonedx", "-o", self.result_file])
+            sanitized_args = append_sbom_scanner_flags(sanitized_args)
             if self.container_mode:
                 sanitized_args = normalize_sbom_args_for_docker(
                     self.command or "", sanitized_args

--- a/aspm_cli/scan/ml_scan.py
+++ b/aspm_cli/scan/ml_scan.py
@@ -1,0 +1,257 @@
+import json
+import os
+import shlex
+import subprocess
+import uuid
+
+from aspm_cli.tool.manager import ToolManager
+from aspm_cli.utils import config, docker_pull
+from aspm_cli.utils.logger import Logger
+from aspm_cli.utils.ml_scan import (
+    build_model_path,
+    build_ondemand_modelscan_payload,
+    count_issues,
+    derive_model_metadata,
+    discover_model_files,
+    load_modelscan_output,
+    merge_modelscan_result,
+    normalize_modelscan_cli_args,
+    parse_scan_path_from_command,
+)
+from aspm_cli.utils.path_safety import resolve_path_within_root
+from aspm_cli.utils.subprocess_utils import run_scan_subprocess
+from colorama import Fore
+
+DEFAULT_ML_SCAN_IMAGE = (
+    "public.ecr.aws/k9v9d5v2/accuknox/ondemand_modelscan:1.0.21"
+)
+DEFAULT_ML_SCAN_MODULE = "ondemand_modelscan"
+DEFAULT_ML_SCAN_TAG = "1.0.21"
+DEFAULT_ML_SCAN_PLATFORM = "linux/amd64"
+
+
+def default_ml_scan_image() -> str:
+    """Resolve ondemand_modelscan image (public ECR by default; on-prem via IMAGE_REGISTRY)."""
+    if os.getenv("ML_SCAN_IMAGE"):
+        return os.getenv("ML_SCAN_IMAGE", "")
+    registry = os.getenv("ML_SCAN_IMAGE_REGISTRY") or os.getenv("IMAGE_REGISTRY")
+    if registry:
+        tag = os.getenv("ML_SCAN_IMAGE_TAG", DEFAULT_ML_SCAN_TAG)
+        module = os.getenv("ML_SCAN_IMAGE_MODULE", DEFAULT_ML_SCAN_MODULE)
+        return f"{registry.rstrip('/')}/{module}:{tag}"
+    return DEFAULT_ML_SCAN_IMAGE
+
+
+def default_ml_scan_docker_platform() -> str:
+    return os.getenv(
+        "ML_SCAN_DOCKER_PLATFORM",
+        os.getenv("DOCKER_DEFAULT_PLATFORM", DEFAULT_ML_SCAN_PLATFORM),
+    )
+
+
+WORK_DIR = "/workdir"
+TEMP_SCAN_DIR = ".accuknox-modelscan"
+
+
+class MLScanScanner:
+    result_file = "results.json"
+
+    def __init__(
+        self,
+        command,
+        container_mode=False,
+        repo_url=None,
+        commit_ref=None,
+        model_name=None,
+        source_type="github",
+    ):
+        self.command = command
+        self.container_mode = container_mode
+        self.scan_image = os.getenv("SCAN_IMAGE", default_ml_scan_image())
+        self.repo_url = repo_url
+        self.commit_ref = commit_ref
+        self.model_name = model_name
+        self.source_type = source_type or "github"
+        self.cwd = os.getcwd()
+
+    def run(self):
+        temp_files = []
+        try:
+            if self.container_mode:
+                docker_pull(
+                    self.scan_image,
+                    platform=default_ml_scan_docker_platform(),
+                )
+
+            if "--help" in (self.command or ""):
+                cmd = self._build_scan_command(["scan", "--help"], ".")
+                result = run_scan_subprocess(cmd)
+                Logger.log_with_color("INFO", result.stdout or result.stderr, Fore.WHITE)
+                return config.PASS_RETURN_CODE, None
+
+            scan_root = parse_scan_path_from_command(self.command)
+            try:
+                resolve_path_within_root(scan_root, self.cwd)
+            except ValueError as exc:
+                Logger.get_logger().error(str(exc))
+                return config.SOMETHING_WENT_WRONG_RETURN_CODE, None
+
+            model_files = discover_model_files(scan_root, cwd=self.cwd)
+
+            if not model_files:
+                Logger.get_logger().info(
+                    "No model files found to scan. "
+                    f"Looked under '{scan_root}' for extensions: .pkl, .pt, .pth, .h5, .keras, .pb, .ckpt, .npy"
+                )
+                self._write_payload([], scan_root)
+                return config.PASS_RETURN_CODE, self.result_file
+
+            metadata = derive_model_metadata(
+                self.repo_url,
+                self.commit_ref,
+                model_name=self.model_name,
+                source_type=self.source_type,
+            )
+            os.makedirs(TEMP_SCAN_DIR, exist_ok=True)
+
+            modelscan_results = []
+            scan_failures = 0
+
+            for index, model_file in enumerate(model_files, start=1):
+                rel_model_file = os.path.relpath(model_file, self.cwd)
+                Logger.get_logger().info(
+                    f"Scanning model file {index}/{len(model_files)}: {rel_model_file}"
+                )
+                temp_output = os.path.join(
+                    TEMP_SCAN_DIR,
+                    f"{uuid.uuid4().hex}.json",
+                )
+                temp_files.append(temp_output)
+                scan_args = normalize_modelscan_cli_args(
+                    f"scan -p {shlex.quote(rel_model_file)} -r json",
+                    temp_output,
+                )
+                cmd = self._build_scan_command(scan_args, rel_model_file)
+
+                Logger.get_logger().debug(f"Running ML scan: {' '.join(cmd)}")
+                result = run_scan_subprocess(cmd)
+
+                if result.stdout:
+                    Logger.get_logger().debug(
+                        result.stdout.replace("modelscan", "[scanner]")
+                    )
+                if result.stderr:
+                    Logger.get_logger().error(
+                        result.stderr.replace("modelscan", "[scanner]")
+                    )
+
+                # ModelScan exits 0 (clean) or 1 (issues found), same as Checkov/Trivy.
+                # Other codes are runtime errors even if a partial output file exists.
+                if not os.path.exists(temp_output):
+                    scan_failures += 1
+                    Logger.get_logger().error(
+                        f"ModelScan failed for {rel_model_file} "
+                        f"(exit {result.returncode}, no output file)"
+                    )
+                    continue
+
+                if result.returncode not in (0, 1):
+                    scan_failures += 1
+                    Logger.get_logger().error(
+                        f"ModelScan failed for {rel_model_file} (exit {result.returncode})"
+                    )
+                    continue
+
+                raw = load_modelscan_output(temp_output)
+                model_path = build_model_path(
+                    metadata["model_id"],
+                    metadata["commit_ref"],
+                    model_file,
+                    scan_root,
+                    cwd=self.cwd,
+                )
+                modelscan_results.append(merge_modelscan_result(raw, model_path))
+
+            self._write_payload(modelscan_results, scan_root, metadata)
+
+            if scan_failures and not modelscan_results:
+                return config.SOMETHING_WENT_WRONG_RETURN_CODE, None
+
+            issue_count = count_issues(modelscan_results)
+            if issue_count > 0:
+                Logger.get_logger().error(
+                    f"ModelScan found {issue_count} issue(s) across {len(modelscan_results)} model file(s)."
+                )
+                return 1, self.result_file
+
+            Logger.get_logger().info(
+                f"ModelScan completed for {len(modelscan_results)} model file(s) with no issues."
+            )
+            return 0, self.result_file
+        except subprocess.TimeoutExpired:
+            Logger.get_logger().error("ML scan timed out")
+            return config.SOMETHING_WENT_WRONG_RETURN_CODE, None
+        except subprocess.CalledProcessError as e:
+            Logger.get_logger().error(f"Error during ML scan: {e}")
+            raise
+        finally:
+            for temp_file in temp_files:
+                try:
+                    if os.path.exists(temp_file):
+                        os.remove(temp_file)
+                except OSError:
+                    pass
+
+    def _write_payload(self, modelscan_results, scan_root, metadata=None):
+        metadata = metadata or derive_model_metadata(
+            self.repo_url,
+            self.commit_ref,
+            model_name=self.model_name,
+            source_type=self.source_type,
+        )
+        payload = build_ondemand_modelscan_payload(modelscan_results, metadata)
+        with open(self.result_file, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+
+    def _resolve_local_binary(self) -> str:
+        try:
+            return ToolManager.get_path("ml-scan")
+        except (ValueError, FileNotFoundError):
+            return "modelscan"
+
+    def _docker_path(self, host_path: str) -> str:
+        if os.path.isabs(host_path):
+            return os.path.join(WORK_DIR, os.path.relpath(host_path, self.cwd))
+        return os.path.join(WORK_DIR, host_path)
+
+    def _build_scan_command(self, args, rel_model_path: str):
+        if not self.container_mode:
+            return [self._resolve_local_binary(), *args]
+
+        docker_args = []
+        i = 0
+        while i < len(args):
+            arg = args[i]
+            if arg in ("-p", "--path") and i + 1 < len(args):
+                docker_args.extend([arg, self._docker_path(args[i + 1])])
+                i += 2
+                continue
+            if arg in ("-o", "--output") and i + 1 < len(args):
+                docker_args.extend([arg, self._docker_path(args[i + 1])])
+                i += 2
+                continue
+            docker_args.append(arg)
+            i += 1
+
+        cmd = ["docker", "run", "--rm"]
+        platform = default_ml_scan_docker_platform()
+        if platform:
+            cmd.extend(["--platform", platform])
+        cmd.extend([
+            "-v", f"{self.cwd}:{WORK_DIR}",
+            "--workdir", WORK_DIR,
+            "--entrypoint", "modelscan",
+            self.scan_image,
+            *docker_args,
+        ])
+        return cmd

--- a/aspm_cli/scan/sast.py
+++ b/aspm_cli/scan/sast.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 import json
 import os
@@ -30,7 +32,10 @@ class SASTScanner:
         """
         self.command = command
         self.container_mode = container_mode
-        self.severity = [s.strip().upper() for s in (severity).split(',')]
+        self.severity = [
+            s.strip().upper()
+            for s in (severity or "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL").split(",")
+        ]
         self.aiscan_severity = [s.strip().upper() for s in aiscan_severity.split(',')] if ai_analysis and isinstance(aiscan_severity, str) else []
         self.repo_url = repo_url
         self.commit_ref = commit_ref
@@ -223,49 +228,59 @@ class SASTScanner:
         Sanitize raw OpenGrep args:
         - Remove conflicting --json / --output flags
         - Ensure -f (rules directory) is set, defaulting to /rules/default-rules/
-        - Append enforced output flags
+        - Append enforced output flags before scan targets
         """
         args = shlex.split(self.command or "")
         forbidden_flags = {"--json", "--output"}
-        sanitized_args = []
+        sanitized_options = []
+        targets = []
         i = 0
         saw_rules_flag = False
 
+        if args and args[0] == "scan":
+            i = 1
+
         while i < len(args):
-            if args[i] in forbidden_flags:
-                # skip the flag and its value if it requires one
-                if args[i] == "--output":
+            arg = args[i]
+            if arg in forbidden_flags:
+                if arg == "--output":
                     i += 2
-                    continue
                 else:
                     i += 1
-                    continue
+                continue
 
-            if args[i] == "-f":
+            if arg == "-f":
                 saw_rules_flag = True
-                sanitized_args.append(args[i])
+                sanitized_options.append(arg)
                 if i + 1 < len(args):
-                    sanitized_args.append(args[i + 1])
+                    sanitized_options.append(args[i + 1])
                     i += 2
                     continue
 
-            sanitized_args.append(args[i])
+            if arg.startswith("-"):
+                sanitized_options.append(arg)
+                if (
+                    "=" not in arg
+                    and i + 1 < len(args)
+                    and not args[i + 1].startswith("-")
+                ):
+                    sanitized_options.append(args[i + 1])
+                    i += 2
+                    continue
+            else:
+                targets.append(arg)
             i += 1
 
-        # Ensure rules path (-f) is set
-        if not self.container_mode:
-            sast_binary = ToolManager.get_path("sast")
-        default_rules = "/rules/default-rules/" if self.container_mode else ToolManager.get_path("sast-rules")
+        default_rules = (
+            "/rules/default-rules/"
+            if self.container_mode
+            else ToolManager.get_path("sast-rules")
+        )
         if not saw_rules_flag:
-            sanitized_args.extend(["-f", default_rules])
+            sanitized_options.extend(["-f", default_rules])
 
-        # Enforce output format
-        sanitized_args.extend([
-            "--json",
-            "--output", self.result_file,
-        ])
-
-        return sanitized_args
+        output_path = "/app/results.json" if self.container_mode else self.result_file
+        return ["scan", *sanitized_options, "--json", "--output", output_path, *targets]
         
         
     def _fix_file_permissions_if_docker(self):

--- a/aspm_cli/scan/sca.py
+++ b/aspm_cli/scan/sca.py
@@ -1,0 +1,20 @@
+from aspm_cli.scan.trivy_runner import run_trivy_vuln_scan, validate_sca_command
+
+
+class SCAScanner:
+    result_file = "./results.json"
+
+    def __init__(self, command, container_mode=False, severity=None):
+        self.command = command
+        self.container_mode = container_mode
+        self.severity = severity
+
+    def run(self):
+        return run_trivy_vuln_scan(
+            self.command,
+            self.container_mode,
+            self.result_file,
+            validate_command=validate_sca_command,
+            cli_severity=self.severity,
+            sca_mode=True,
+        )

--- a/aspm_cli/scan/secret.py
+++ b/aspm_cli/scan/secret.py
@@ -1,98 +1,113 @@
-import subprocess
 import os
 import shlex
+import subprocess
+
 from aspm_cli.tool.manager import ToolManager
-from aspm_cli.utils import docker_pull
+from aspm_cli.utils import config, docker_pull
 from aspm_cli.utils.logger import Logger
 from colorama import Fore
-from aspm_cli.utils import config
+
+TRUFFLEHOG_IMAGE = "public.ecr.aws/k9v9d5v2/trufflesecurity/trufflehog:3.90.3"
+GITLEAKS_IMAGE = "ghcr.io/gitleaks/gitleaks:v8.24.2"
+
 
 class SecretScanner:
-    ak_secretscan_image = os.getenv("SCAN_IMAGE", "public.ecr.aws/k9v9d5v2/trufflesecurity/trufflehog:3.90.3")
-    result_file = 'results.jsonl'
-
-    def __init__(self, command, container_mode=False):
-        """
-        :param command: Raw ak_secretscan CLI arguments string
-        :param container_mode: Run locally if True, else use Docker
-        """
+    def __init__(self, command, container_mode=False, engine="trufflehog"):
         self.command = command
         self.container_mode = container_mode
+        self.engine = engine.lower()
+
+    @property
+    def result_file(self):
+        return "results.json" if self.engine == "gitleaks" else "results.jsonl"
+
+    @property
+    def scan_image(self):
+        if self.engine == "gitleaks":
+            return os.getenv("GITLEAKS_IMAGE", GITLEAKS_IMAGE)
+        return os.getenv("SCAN_IMAGE", TRUFFLEHOG_IMAGE)
 
     def run(self):
         try:
-            Logger.get_logger().debug("Starting Secret Scan using ak_secretscan...")
+            Logger.get_logger().debug(f"Starting secret scan using {self.engine}...")
             if self.container_mode:
-                docker_pull(self.ak_secretscan_image)
+                docker_pull(self.scan_image)
 
-            args = self._build_secretscan_args()
-            cmd = self._build_secretscan_command(args)
-
-            Logger.get_logger().debug(f"Running command: {' '.join(cmd)}")
-            result = subprocess.run(cmd, capture_output=True, text=True)
-
-            if result.stdout:
-                sanitized_stdout = result.stdout.replace("TruffleHog", "[scanner]")
-                Logger.get_logger().debug(sanitized_stdout)
-
-                if("--help" in self.command):
-                    Logger.log_with_color('INFO', sanitized_stdout, Fore.WHITE)
-                    return config.PASS_RETURN_CODE, None
-            if result.stderr:
-                sanitized_stderr = result.stderr.replace("TruffleHog", "[scanner]")
-
-                if("--help" in self.command and result.returncode == 0):
-                    Logger.log_with_color('INFO', sanitized_stderr, Fore.WHITE)
-                    return config.PASS_RETURN_CODE, None
-                else:
-                    Logger.get_logger().error(sanitized_stderr)
-
-            with open(self.result_file, 'w') as f:
-                f.write(result.stdout)
-
-            if os.path.exists(self.result_file) and os.stat(self.result_file).st_size > 0:
-                return result.returncode, self.result_file
-            else:
-                Logger.get_logger().info("No secrets found. Skipping upload.")
-                return result.returncode, None
-
+            if self.engine == "gitleaks":
+                return self._run_gitleaks()
+            return self._run_trufflehog()
         except subprocess.CalledProcessError as e:
             Logger.get_logger().error(f"Error during Secret scan: {e}")
             raise
 
-    def _build_secretscan_args(self):
-        """
-        Parse raw command, filter conflicting flags, and append mandatory ones.
-        """
-        args = shlex.split(self.command)
+    def _run_trufflehog(self):
+        args = self._build_trufflehog_args()
+        cmd = self._build_scan_command(args, tool_name="secret")
+        return self._execute_scan(cmd, brand="TruffleHog", write_stdout=True)
 
-        # Strip known conflicting or redundant flags
+    def _run_gitleaks(self):
+        args = self._build_gitleaks_args()
+        cmd = self._build_scan_command(args, tool_name="gitleaks", entrypoint_gitleaks=True)
+        return self._execute_scan(cmd, brand="Gitleaks", write_stdout=False)
+
+    def _execute_scan(self, cmd, brand: str, write_stdout: bool):
+        Logger.get_logger().debug(f"Running command: {' '.join(cmd)}")
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        if result.stdout:
+            sanitized_stdout = result.stdout.replace(brand, "[scanner]")
+            Logger.get_logger().debug(sanitized_stdout)
+            if "--help" in (self.command or ""):
+                Logger.log_with_color("INFO", sanitized_stdout, Fore.WHITE)
+                return config.PASS_RETURN_CODE, None
+
+        if result.stderr:
+            sanitized_stderr = result.stderr.replace(brand, "[scanner]")
+            if "--help" in (self.command or "") and result.returncode == 0:
+                Logger.log_with_color("INFO", sanitized_stderr, Fore.WHITE)
+                return config.PASS_RETURN_CODE, None
+            Logger.get_logger().error(sanitized_stderr)
+
+        if write_stdout:
+            with open(self.result_file, "w", encoding="utf-8") as f:
+                f.write(result.stdout)
+
+        if os.path.exists(self.result_file) and os.stat(self.result_file).st_size > 0:
+            return result.returncode, self.result_file
+
+        Logger.get_logger().info("No secrets found. Skipping upload.")
+        return result.returncode, None
+
+    def _build_trufflehog_args(self):
+        args = shlex.split(self.command or "")
         forbidden_flags = {"--json", "--fail", "--no-update"}
-        sanitized_args = []
-        i = 0
-        while i < len(args):
-            if args[i] in forbidden_flags:
-                i += 1
-                continue
-            sanitized_args.append(args[i])
-            i += 1
-
+        sanitized_args = [arg for arg in args if arg not in forbidden_flags]
         sanitized_args.extend(["--json", "--fail", "--no-update"])
         return sanitized_args
 
-    def _build_secretscan_command(self, args):
-        """
-        Construct the full command with target and args.
-        """
-        if not self.container_mode:
-            cmd = [ToolManager.get_path("secret")]
-        else:
-            cmd = [
-                "docker", "run", "--rm",
-                "-v", f"{os.getcwd()}:/app",
-                "--workdir", "/app",
-                self.ak_secretscan_image
-            ]
+    def _build_gitleaks_args(self):
+        if self.command and self.command.strip():
+            return shlex.split(self.command)
 
+        return [
+            "detect",
+            "--source", ".",
+            "--report-format", "json",
+            "--report-path", self.result_file,
+            "--no-banner",
+        ]
+
+    def _build_scan_command(self, args, tool_name: str, entrypoint_gitleaks: bool = False):
+        if not self.container_mode:
+            return [ToolManager.get_path(tool_name), *args]
+
+        cmd = [
+            "docker", "run", "--rm",
+            "-v", f"{os.getcwd()}:/app",
+            "--workdir", "/app",
+        ]
+        if entrypoint_gitleaks:
+            cmd.extend(["--entrypoint", "gitleaks"])
+        cmd.append(self.scan_image)
         cmd.extend(args)
         return cmd

--- a/aspm_cli/scan/secret.py
+++ b/aspm_cli/scan/secret.py
@@ -92,7 +92,7 @@ class SecretScanner:
         return [
             "detect",
             "--source", ".",
-            "--report-format", "json",
+            "--report-format", "sarif",
             "--report-path", self.result_file,
             "--no-banner",
         ]

--- a/aspm_cli/scan/trivy_runner.py
+++ b/aspm_cli/scan/trivy_runner.py
@@ -1,0 +1,163 @@
+import json
+import os
+import re
+import shlex
+import subprocess
+from typing import List, Optional, Tuple
+
+from aspm_cli.tool.manager import ToolManager
+from aspm_cli.utils import config, docker_pull
+from aspm_cli.utils.logger import Logger
+from aspm_cli.utils.subprocess_utils import run_scan_subprocess
+from aspm_cli.utils.sca_prepare import append_skip_git_dir, normalize_sca_trivy_report
+from aspm_cli.utils.sbom import (
+    FILESYSTEM_SUBCOMMANDS,
+    normalize_filesystem_args_for_docker,
+    parse_trivy_subcommand,
+)
+
+DEFAULT_TRIVY_IMAGE = "public.ecr.aws/k9v9d5v2/accuknox/trivy:0.69.3"
+SCA_ALLOWED_SUBCOMMANDS = frozenset({"filesystem", "fs", "rootfs"})
+
+
+def get_trivy_image() -> str:
+    return os.getenv("SCAN_IMAGE", DEFAULT_TRIVY_IMAGE)
+
+
+def validate_sca_command(command: str) -> None:
+    subcommand = parse_trivy_subcommand(command)
+    if subcommand not in SCA_ALLOWED_SUBCOMMANDS:
+        raise ValueError(
+            "Invalid command for SCA scan. "
+            f"First argument must be one of: {', '.join(sorted(SCA_ALLOWED_SUBCOMMANDS))}. "
+            "Example: 'fs .'"
+        )
+
+
+def build_trivy_vuln_args(
+    command: str,
+    result_file: str,
+    cli_severity: Optional[str] = None,
+) -> Tuple[Optional[str], List[str]]:
+    """Parse Trivy command, strip conflicting flags, enforce JSON vuln output."""
+    flags_to_strip = {"-s", "--severity", "-o", "--output", "-f", "--format", "--exit-code", "--quiet"}
+    severity_threshold = None
+    original_args = shlex.split(command or "")
+    sanitized_args = []
+
+    i = 0
+    while i < len(original_args):
+        arg = original_args[i]
+        if arg in flags_to_strip:
+            if arg in ("-s", "--severity") and i + 1 < len(original_args):
+                severity_threshold = original_args[i + 1]
+            i += 2
+            continue
+        sanitized_args.append(arg)
+        i += 1
+
+    sanitized_args.extend(["--quiet", "--exit-code", "1", "-f", "json", "-o", result_file])
+    if severity_threshold is None and cli_severity:
+        severity_threshold = cli_severity
+    return severity_threshold, sanitized_args
+
+
+def normalize_sca_args_for_docker(command: str, sanitized_args: List[str]) -> List[str]:
+    subcommand = parse_trivy_subcommand(command)
+    if subcommand in FILESYSTEM_SUBCOMMANDS:
+        return normalize_filesystem_args_for_docker(sanitized_args)
+    return sanitized_args
+
+
+def build_trivy_scan_command(
+    container_mode: bool,
+    scan_args: List[str],
+    image: Optional[str] = None,
+) -> List[str]:
+    image = image or get_trivy_image()
+    if not container_mode:
+        return [ToolManager.get_path("container"), *scan_args]
+
+    return [
+        "docker", "run", "--rm",
+        "-v", "/var/run/docker.sock:/var/run/docker.sock",
+        "-v", f"{os.getcwd()}:/workdir",
+        "--workdir", "/workdir",
+        image,
+        *scan_args,
+    ]
+
+
+def sanitize_trivy_log(text: str) -> str:
+    return re.sub(r"trivy|aquasecurity|aqua security", "[scanner]", text, flags=re.IGNORECASE)
+
+
+def severity_threshold_met(result_file: str, severity_threshold: List[str]) -> bool:
+    with open(result_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    for result in data.get("Results", []):
+        for vuln in result.get("Vulnerabilities", []):
+            if vuln.get("Severity", "").upper() in severity_threshold:
+                return True
+    return False
+
+
+def run_trivy_vuln_scan(
+    command: str,
+    container_mode: bool,
+    result_file: str = "./results.json",
+    validate_command=None,
+    cli_severity: Optional[str] = None,
+    sca_mode: bool = False,
+) -> Tuple[int, Optional[str]]:
+    if validate_command:
+        validate_command(command)
+
+    if container_mode:
+        docker_pull(get_trivy_image())
+
+    severity_threshold, sanitized_args = build_trivy_vuln_args(
+        command, result_file, cli_severity=cli_severity
+    )
+    if sca_mode:
+        sanitized_args = append_skip_git_dir(sanitized_args)
+    if container_mode:
+        sanitized_args = normalize_sca_args_for_docker(command, sanitized_args)
+
+    scan_cmd = build_trivy_scan_command(container_mode, sanitized_args)
+    Logger.get_logger().debug(f"Running Trivy vuln scan: {' '.join(scan_cmd)}")
+    try:
+        result = run_scan_subprocess(scan_cmd)
+    except subprocess.TimeoutExpired:
+        Logger.get_logger().error("Trivy scan timed out")
+        return config.SOMETHING_WENT_WRONG_RETURN_CODE, None
+
+    if result.stdout:
+        Logger.get_logger().debug(sanitize_trivy_log(result.stdout))
+        if "--help" in (command or ""):
+            from colorama import Fore
+            Logger.log_with_color("INFO", sanitize_trivy_log(result.stdout), Fore.WHITE)
+            return config.PASS_RETURN_CODE, None
+    if result.stderr:
+        Logger.get_logger().error(sanitize_trivy_log(result.stderr))
+
+    if not os.path.exists(result_file):
+        return config.SOMETHING_WENT_WRONG_RETURN_CODE, None
+
+    if sca_mode and normalize_sca_trivy_report(result_file):
+        Logger.get_logger().debug(
+            "SCA: normalized Trivy ArtifactType repository -> filesystem for platform parsing"
+        )
+
+    thresholds = [
+        s.strip().upper()
+        for s in (severity_threshold or "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL").split(",")
+    ]
+    if severity_threshold_met(result_file, thresholds):
+        Logger.get_logger().error(
+            f"Vulnerabilities matching severities: {', '.join(thresholds)} found."
+        )
+        return 1, result_file
+
+    return 0, result_file

--- a/aspm_cli/scanners/__init__.py
+++ b/aspm_cli/scanners/__init__.py
@@ -4,6 +4,9 @@ from .sq_sast_scanner import SQSASTScanner
 from .secret_scanner import SecretScanner
 from .container_scanner import ContainerScanner
 from .dast_scanner import DASTScanner
+from .sca_scanner import SCAScanner
+from .ml_scan_scanner import MLScanScanner
+from .api_discovery_scanner import APIDiscoveryScanner
 
 scanner_registry = {
     "IAC": IACScanner,
@@ -12,4 +15,7 @@ scanner_registry = {
     "SECRET": SecretScanner,
     "CONTAINER": ContainerScanner,
     "DAST": DASTScanner,
+    "SCA": SCAScanner,
+    "ML-SCAN": MLScanScanner,
+    "API-DISCOVERY": APIDiscoveryScanner,
 }

--- a/aspm_cli/scanners/api_discovery_scanner.py
+++ b/aspm_cli/scanners/api_discovery_scanner.py
@@ -1,0 +1,36 @@
+import argparse
+
+from aspm_cli.scanners.base_scanner import BaseScanner
+from aspm_cli.scan.api_discovery import APIDiscoveryScanner as OriginalAPIDiscoveryScanner
+from aspm_cli.utils.config import ConfigValidator
+from aspm_cli.utils.git_info import GitInfo
+
+
+class APIDiscoveryScanner(BaseScanner):
+    help_text = "Run API discovery scan using code2api (static route discovery from source)"
+    data_type_identifier = "API"
+
+    def add_arguments(self, parser: argparse.ArgumentParser):
+        parser.add_argument(
+            "--command",
+            type=str,
+            default="-path . -output results.json",
+            help="code2api args (default: '-path . -output results.json')",
+        )
+        parser.add_argument(
+            "--container-mode",
+            action="store_true",
+            help="Run code2api in container mode",
+        )
+        parser.add_argument(
+            "--repo-url",
+            default=GitInfo.get_repo_url(),
+            help="Repository URL (recorded in CI; optional metadata for uploads)",
+        )
+
+    def validate_config(self, args: argparse.Namespace, validator: ConfigValidator):
+        validator.validate_api_discovery_scan(args.command, args.container_mode)
+
+    def run_scan(self, args: argparse.Namespace) -> tuple[int, str]:
+        scanner = OriginalAPIDiscoveryScanner(args.command, args.container_mode)
+        return scanner.run()

--- a/aspm_cli/scanners/base_scanner.py
+++ b/aspm_cli/scanners/base_scanner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 import argparse
 
@@ -15,6 +17,9 @@ class BaseScanner(ABC):
     def __init__(self):
         # Placeholder for common scanner initialization if needed
         pass
+
+    def get_data_type_identifier(self) -> str:
+        return self.data_type_identifier
 
     @abstractmethod
     def add_arguments(self, parser: argparse.ArgumentParser):

--- a/aspm_cli/scanners/ml_scan_scanner.py
+++ b/aspm_cli/scanners/ml_scan_scanner.py
@@ -1,0 +1,64 @@
+import argparse
+
+from aspm_cli.scanners.base_scanner import BaseScanner
+from aspm_cli.scan.ml_scan import MLScanScanner as OriginalMLScanScanner
+from aspm_cli.utils.config import ConfigValidator
+from aspm_cli.utils.git_info import GitInfo
+
+
+class MLScanScanner(BaseScanner):
+    help_text = "Run ML static model scan using ModelScan"
+    data_type_identifier = "MLCHECKS"
+
+    def add_arguments(self, parser: argparse.ArgumentParser):
+        parser.add_argument(
+            "--command",
+            type=str,
+            default="scan -p . -r json",
+            help="ModelScan args (default: 'scan -p . -r json'; discovers model files under -p path)",
+        )
+        parser.add_argument(
+            "--container-mode",
+            action="store_true",
+            help="Run in container mode",
+        )
+        parser.add_argument(
+            "--repo-url",
+            default=GitInfo.get_repo_url(),
+            help="Repository URL or CI project path (used in upload metadata)",
+        )
+        parser.add_argument(
+            "--commit-ref",
+            default=GitInfo.get_commit_ref(),
+            help="Branch or ref (used in model_path metadata)",
+        )
+        parser.add_argument(
+            "--model-name",
+            help="Collector/project name in ondemand_modelscan payload (defaults to repo name)",
+        )
+        parser.add_argument(
+            "--source-type",
+            default="github",
+            help="Source type in upload payload (default: github)",
+        )
+
+    def validate_config(self, args: argparse.Namespace, validator: ConfigValidator):
+        validator.validate_ml_scan(
+            args.command,
+            args.container_mode,
+            args.repo_url,
+            args.commit_ref,
+            args.model_name,
+            args.source_type,
+        )
+
+    def run_scan(self, args: argparse.Namespace) -> tuple[int, str]:
+        scanner = OriginalMLScanScanner(
+            command=args.command,
+            container_mode=args.container_mode,
+            repo_url=args.repo_url,
+            commit_ref=args.commit_ref,
+            model_name=args.model_name,
+            source_type=args.source_type,
+        )
+        return scanner.run()

--- a/aspm_cli/scanners/ml_scan_scanner.py
+++ b/aspm_cli/scanners/ml_scan_scanner.py
@@ -8,7 +8,7 @@ from aspm_cli.utils.git_info import GitInfo
 
 class MLScanScanner(BaseScanner):
     help_text = "Run ML static model scan using ModelScan"
-    data_type_identifier = "MLCHECKS"
+    data_type_identifier = "MLC"
 
     def add_arguments(self, parser: argparse.ArgumentParser):
         parser.add_argument(

--- a/aspm_cli/scanners/sast_scanner.py
+++ b/aspm_cli/scanners/sast_scanner.py
@@ -1,11 +1,12 @@
 import argparse
+import os
 from aspm_cli.scanners.base_scanner import BaseScanner
 from aspm_cli.utils.config import ConfigValidator
 from aspm_cli.utils.git_info import GitInfo
 from aspm_cli.scan.sast import SASTScanner as OriginalSASTScanner 
 
 class SASTScanner(BaseScanner):
-    help_text = "Run Static Application Security Testing (SAST) scan using Semgrep"
+    help_text = "Run Static Application Security Testing (SAST) scan using OpenGrep"
     data_type_identifier = "SG"
 
     def add_arguments(self, parser: argparse.ArgumentParser):
@@ -44,17 +45,19 @@ class SASTScanner(BaseScanner):
         )
 
     def run_scan(self, args: argparse.Namespace) -> tuple[int, str]:
+        env_ai = os.getenv("ACCUKNOX_ENABLE_AI_SAST", "").upper()
+        ai_analysis = args.ai_analysis or env_ai in ("TRUE", "1", "YES")
         scanner = OriginalSASTScanner(
             command=args.command,
             container_mode=args.container_mode,
             severity=args.severity,
-            aiscan_severity=args.aiscan_severity if args.ai_analysis else [],
+            aiscan_severity=args.aiscan_severity if ai_analysis else [],
             repo_url=args.repo_url,
             commit_ref=args.commit_ref,
             commit_sha=args.commit_sha,
             pipeline_id=args.pipeline_id,
             job_url=args.job_url,
-            ai_analysis=args.ai_analysis,
+            ai_analysis=ai_analysis,
             codeassure_config=getattr(args, 'codeassure_config', None)
         )
         return scanner.run()

--- a/aspm_cli/scanners/sca_scanner.py
+++ b/aspm_cli/scanners/sca_scanner.py
@@ -1,0 +1,39 @@
+import argparse
+
+from aspm_cli.scanners.base_scanner import BaseScanner
+from aspm_cli.scan.sca import SCAScanner as OriginalSCAScanner
+from aspm_cli.utils.config import ConfigValidator
+
+
+class SCAScanner(BaseScanner):
+    help_text = "Run Software Composition Analysis (SCA) using Trivy filesystem scan"
+    data_type_identifier = "TR"
+
+    def add_arguments(self, parser: argparse.ArgumentParser):
+        parser.add_argument(
+            "--command",
+            type=str,
+            required=True,
+            help="Trivy filesystem args (e.g. 'fs .')",
+        )
+        parser.add_argument(
+            "--container-mode",
+            action="store_true",
+            help="Run in container mode",
+        )
+        parser.add_argument(
+            "--severity",
+            default="UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
+            help="Comma-separated severities that fail the scan",
+        )
+
+    def validate_config(self, args: argparse.Namespace, validator: ConfigValidator):
+        validator.validate_sca_scan(args.command, args.container_mode, args.severity)
+
+    def run_scan(self, args: argparse.Namespace) -> tuple[int, str]:
+        scanner = OriginalSCAScanner(
+            args.command,
+            args.container_mode,
+            severity=args.severity,
+        )
+        return scanner.run()

--- a/aspm_cli/scanners/secret_scanner.py
+++ b/aspm_cli/scanners/secret_scanner.py
@@ -12,7 +12,7 @@ class SecretScanner(BaseScanner):
     def __init__(self, engine: str = "trufflehog"):
         super().__init__()
         self.engine = engine.lower()
-        self.data_type_identifier = "Gitleaks" if self.engine == "gitleaks" else "TruffleHog"
+        self.data_type_identifier = "DS" if self.engine == "gitleaks" else "TruffleHog"
 
     def add_arguments(self, parser: argparse.ArgumentParser):
         parser.add_argument(
@@ -39,6 +39,6 @@ class SecretScanner(BaseScanner):
     def run_scan(self, args: argparse.Namespace) -> tuple[int, str]:
         engine = args.engine.lower()
         self.engine = engine
-        self.data_type_identifier = "Gitleaks" if engine == "gitleaks" else "TruffleHog"
+        self.data_type_identifier = "DS" if engine == "gitleaks" else "TruffleHog"
         scanner = OriginalSecretScanner(args.command, args.container_mode, engine=engine)
         return scanner.run()

--- a/aspm_cli/scanners/secret_scanner.py
+++ b/aspm_cli/scanners/secret_scanner.py
@@ -1,28 +1,44 @@
 import argparse
+
 from aspm_cli.scanners.base_scanner import BaseScanner
-from aspm_cli.utils.config import ConfigValidator
 from aspm_cli.scan.secret import SecretScanner as OriginalSecretScanner
+from aspm_cli.utils.config import ConfigValidator
+
 
 class SecretScanner(BaseScanner):
-    help_text = "Run Secret scan using TruffleHog"
+    help_text = "Run secret scan using TruffleHog or Gitleaks"
     data_type_identifier = "TruffleHog"
+
+    def __init__(self, engine: str = "trufflehog"):
+        super().__init__()
+        self.engine = engine.lower()
+        self.data_type_identifier = "Gitleaks" if self.engine == "gitleaks" else "TruffleHog"
 
     def add_arguments(self, parser: argparse.ArgumentParser):
         parser.add_argument(
             "--command",
             type=str,
             required=True,
-            help="Arguments to pass to the secret scanner (e.g., 'git file://.')"
+            help="Scanner args (TruffleHog: 'filesystem .'; Gitleaks: 'detect --source .')",
         )
         parser.add_argument(
             "--container-mode",
             action="store_true",
-            help="Run in container mode"
+            help="Run in container mode",
+        )
+        parser.add_argument(
+            "--engine",
+            choices=["trufflehog", "gitleaks"],
+            default="trufflehog",
+            help="Secret scanner engine (default: trufflehog)",
         )
 
     def validate_config(self, args: argparse.Namespace, validator: ConfigValidator):
-        validator.validate_secret_scan(args.command, args.container_mode)
+        validator.validate_secret_scan(args.command, args.container_mode, args.engine)
 
     def run_scan(self, args: argparse.Namespace) -> tuple[int, str]:
-        scanner = OriginalSecretScanner(args.command, args.container_mode)
+        engine = args.engine.lower()
+        self.engine = engine
+        self.data_type_identifier = "Gitleaks" if engine == "gitleaks" else "TruffleHog"
+        scanner = OriginalSecretScanner(args.command, args.container_mode, engine=engine)
         return scanner.run()

--- a/aspm_cli/tool/download.py
+++ b/aspm_cli/tool/download.py
@@ -20,7 +20,8 @@ class ToolDownloader:
             "sq-sast": "https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.10.1/sq-sast.tar.gz",
             "sast": "https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.10.1/sast.tar.gz",
             "dast": "https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.10.1/dast.tar.gz",
-            "codeassure": "https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.6/codeassure.tar.gz"
+            "codeassure": "https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.6/codeassure.tar.gz",
+            "gitleaks": "https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.6/gitleaks.tar.gz",
         },
     }
 

--- a/aspm_cli/tool/manager.py
+++ b/aspm_cli/tool/manager.py
@@ -39,6 +39,8 @@ class ToolManager:
         "sast": Path("sast") / "sast",
         "sast-rules": Path("sast") / "rules",
         "codeassure": Path("codeassure") / "codeassure",
+        "gitleaks": Path("gitleaks"),
+        "api-discovery": Path("code2api"),
     }
 
 

--- a/aspm_cli/utils/api_discovery.py
+++ b/aspm_cli/utils/api_discovery.py
@@ -1,0 +1,114 @@
+import os
+import shlex
+from typing import List, Optional
+
+DEFAULT_RESULT_FILE = "results.json"
+DOCKER_WORKDIR = "/workdir"
+
+
+def parse_scan_path_from_command(command: str) -> str:
+    """Extract -path / legacy --source from a code2api command string."""
+    args = shlex.split(command or "-path .")
+    if args and args[0] == "scan":
+        return _legacy_scan_path(args)
+
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-path", "--path") and i + 1 < len(args):
+            return args[i + 1]
+        i += 1
+    return "."
+
+
+def _legacy_scan_path(args: List[str]) -> str:
+    i = 1
+    while i < len(args):
+        if args[i] in ("--source", "-source") and i + 1 < len(args):
+            return args[i + 1]
+        i += 1
+    return "."
+
+
+def normalize_code2api_args(command: str, output_file: str = DEFAULT_RESULT_FILE) -> List[str]:
+    """
+    Build code2api CLI args: -path <dir> -output <file>.
+    Accepts legacy placeholder commands: scan --source . --output results.json
+    """
+    args = shlex.split(command or "-path .")
+
+    if args and args[0] == "scan":
+        path = _legacy_scan_path(args)
+        output = output_file
+        i = 1
+        while i < len(args):
+            if args[i] in ("--output", "-output") and i + 1 < len(args):
+                output = args[i + 1]
+                i += 2
+                continue
+            i += 1
+        return ["-path", path, "-output", output]
+
+    normalized: List[str] = []
+    has_path = False
+    has_output = False
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-path", "--path"):
+            if i + 1 < len(args):
+                normalized.extend(["-path", args[i + 1]])
+                has_path = True
+                i += 2
+                continue
+        elif arg in ("-output", "--output"):
+            if i + 1 < len(args):
+                normalized.extend(["-output", args[i + 1]])
+                has_output = True
+                i += 2
+                continue
+        elif arg == "-verbose":
+            normalized.append("-verbose")
+            i += 1
+            continue
+        elif arg == "-version":
+            normalized.append("-version")
+            i += 1
+            continue
+        i += 1
+
+    if not has_path:
+        normalized.extend(["-path", "."])
+    if not has_output:
+        normalized.extend(["-output", output_file])
+    return normalized
+
+
+def normalize_code2api_args_for_docker(args: List[str], cwd: Optional[str] = None) -> List[str]:
+    """Rewrite relative -path values for container /workdir mount."""
+    cwd = cwd or os.getcwd()
+    result = list(args)
+    try:
+        path_idx = result.index("-path")
+    except ValueError:
+        return result
+
+    if path_idx + 1 >= len(result):
+        return result
+
+    target = result[path_idx + 1]
+    if target in (".", ""):
+        result[path_idx + 1] = DOCKER_WORKDIR
+    elif not os.path.isabs(target) and not target.startswith(DOCKER_WORKDIR):
+        result[path_idx + 1] = f"{DOCKER_WORKDIR}/{target.lstrip('./')}"
+
+    try:
+        output_idx = result.index("-output")
+        if output_idx + 1 < len(result):
+            output = result[output_idx + 1]
+            if not os.path.isabs(output) and not output.startswith(DOCKER_WORKDIR):
+                result[output_idx + 1] = f"{DOCKER_WORKDIR}/{output.lstrip('./')}"
+    except ValueError:
+        pass
+
+    return result

--- a/aspm_cli/utils/common.py
+++ b/aspm_cli/utils/common.py
@@ -12,7 +12,17 @@ from aspm_cli.utils.logger import Logger
 from aspm_cli.utils.spinner import Spinner
 
 # Moved from original main.py
-ALLOWED_SCAN_TYPES = ["iac", "sq-sast", "secret", "container", "sast", "dast"]
+ALLOWED_SCAN_TYPES = [
+    "iac",
+    "sq-sast",
+    "secret",
+    "container",
+    "sast",
+    "dast",
+    "sca",
+    "ml-scan",
+    "api-discovery",
+]
 
 def _build_endpoint_url(endpoint, api_path):
     """

--- a/aspm_cli/utils/config.py
+++ b/aspm_cli/utils/config.py
@@ -168,17 +168,97 @@ class ConfigValidator:
             Logger.get_logger().debug(f"SQ SAST scan configuration error: {concise_msg}")
             raise ValueError(concise_msg)
 
-    def validate_secret_scan(self, command: str, container_mode: bool):
+    def validate_secret_scan(self, command: str, container_mode: bool, engine: str = "trufflehog"):
         class SecretScanConfig(BaseModel):
             command: str = Field(..., min_length=1, description="Command arguments for Secret scanner")
             container_mode: bool
+            engine: Literal["trufflehog", "gitleaks"] = "trufflehog"
 
         try:
-            SecretScanConfig(command=command, container_mode=container_mode)
+            SecretScanConfig(command=command, container_mode=container_mode, engine=engine)
             self._log_validation_success("Secret")
         except ValidationError as e:
             concise_msg = _format_validation_error(e)
             Logger.get_logger().debug(f"Secret scan configuration error: {concise_msg}")
+            raise ValueError(concise_msg)
+
+    def validate_sca_scan(self, command: str, container_mode: bool, severity: str):
+        from aspm_cli.scan.trivy_runner import validate_sca_command
+
+        class SCAScanConfig(BaseModel):
+            command: str = Field(..., min_length=1, description="Command arguments for SCA scanner")
+            container_mode: bool
+            severity: str = Field(..., description="Comma-separated list of severities")
+
+            @field_validator("severity", mode="before")
+            @classmethod
+            def validate_severity(cls, v: str, info: FieldValidationInfo):
+                allowed_severities = {"UNKNOWN", "LOW", "MEDIUM", "HIGH", "CRITICAL"}
+                if not isinstance(v, str):
+                    raise ValueError("Severity must be a comma-separated string.")
+                provided_severities = {s.strip().upper() for s in v.split(",") if s.strip()}
+                if not provided_severities:
+                    raise ValueError("At least one severity must be provided.")
+                invalid = provided_severities - allowed_severities
+                if invalid:
+                    raise ValueError(
+                        f"Invalid severity values: {', '.join(sorted(invalid))}. "
+                        f"Allowed values: {', '.join(sorted(allowed_severities))}."
+                    )
+                return ",".join(sorted(provided_severities))
+
+        try:
+            SCAScanConfig(command=command, container_mode=container_mode, severity=severity)
+            validate_sca_command(command)
+            self._log_validation_success("SCA")
+        except ValidationError as e:
+            concise_msg = _format_validation_error(e)
+            Logger.get_logger().debug(f"SCA scan configuration error: {concise_msg}")
+            raise ValueError(concise_msg)
+
+    def validate_ml_scan(
+        self,
+        command: str,
+        container_mode: bool,
+        repo_url: Optional[str] = None,
+        commit_ref: Optional[str] = None,
+        model_name: Optional[str] = None,
+        source_type: Optional[str] = None,
+    ):
+        class MLScanConfig(BaseModel):
+            command: str = Field(..., min_length=1, description="Command arguments for ML scan")
+            container_mode: bool
+            repo_url: Optional[str] = None
+            commit_ref: Optional[str] = None
+            model_name: Optional[str] = None
+            source_type: Optional[str] = "github"
+
+        try:
+            MLScanConfig(
+                command=command,
+                container_mode=container_mode,
+                repo_url=repo_url,
+                commit_ref=commit_ref,
+                model_name=model_name,
+                source_type=source_type,
+            )
+            self._log_validation_success("ML Scan")
+        except ValidationError as e:
+            concise_msg = _format_validation_error(e)
+            Logger.get_logger().debug(f"ML scan configuration error: {concise_msg}")
+            raise ValueError(concise_msg)
+
+    def validate_api_discovery_scan(self, command: str, container_mode: bool):
+        class APIDiscoveryScanConfig(BaseModel):
+            command: str = Field(..., min_length=1, description="Command arguments for API discovery scan")
+            container_mode: bool
+
+        try:
+            APIDiscoveryScanConfig(command=command, container_mode=container_mode)
+            self._log_validation_success("API Discovery")
+        except ValidationError as e:
+            concise_msg = _format_validation_error(e)
+            Logger.get_logger().debug(f"API discovery scan configuration error: {concise_msg}")
             raise ValueError(concise_msg)
 
     def validate_container_scan(

--- a/aspm_cli/utils/docker_pull.py
+++ b/aspm_cli/utils/docker_pull.py
@@ -1,17 +1,34 @@
 import subprocess
-import os
 
 from aspm_cli.utils.logger import Logger
 
-def docker_pull(image: str):
-    """Pull a Docker image using subprocess."""
+
+def _image_exists_locally(image: str) -> bool:
+    result = subprocess.run(
+        ["docker", "image", "inspect", image],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def docker_pull(image: str, platform: str = None):
+    """Pull a Docker image, or use it if already present locally."""
+    if _image_exists_locally(image):
+        Logger.get_logger().debug(f"Using local Docker image: {image}")
+        return
+
     Logger.get_logger().debug(f"Pulling Docker image: {image}")
-    result = subprocess.run(["docker", "pull", image], capture_output=True, text=True)
+    cmd = ["docker", "pull"]
+    if platform:
+        cmd.extend(["--platform", platform])
+    cmd.append(image)
+    result = subprocess.run(cmd, capture_output=True, text=True)
 
     if result.returncode != 0:
         Logger.get_logger().error(f"Failed to pull image {image}")
         Logger.get_logger().error(result.stderr)
         raise RuntimeError(f"Failed to pull image: {image}")
-    else:
-        Logger.get_logger().debug(result.stdout)
-        Logger.get_logger().debug(f"Successfully pulled image: {image}")
+
+    Logger.get_logger().debug(result.stdout)
+    Logger.get_logger().debug(f"Successfully pulled image: {image}")

--- a/aspm_cli/utils/git_info.py
+++ b/aspm_cli/utils/git_info.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 from aspm_cli.utils.logger import Logger
 

--- a/aspm_cli/utils/ml_scan.py
+++ b/aspm_cli/utils/ml_scan.py
@@ -1,0 +1,206 @@
+import json
+import os
+import re
+import shlex
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+from aspm_cli.utils.path_safety import resolve_path_within_root
+
+MODEL_EXTENSIONS = frozenset({".pb", ".h5", ".keras", ".pth", ".pt", ".ckpt", ".npy", ".pkl"})
+SKIP_DIR_NAMES = frozenset({".git", ".accuknox-modelscan", "node_modules", "__pycache__"})
+
+
+def parse_scan_path_from_command(command: str) -> str:
+    """Extract the -p/--path target from a modelscan command string."""
+    args = shlex.split(command or "")
+    if args and args[0] == "scan":
+        args = args[1:]
+
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-p", "--path") and i + 1 < len(args):
+            return args[i + 1]
+        if arg.startswith("-p") and arg != "-p" and len(arg) > 2:
+            return arg[2:]
+        i += 1
+    return "."
+
+
+def normalize_modelscan_cli_args(command: str, output_file: str) -> List[str]:
+    """Build modelscan CLI args: scan -p <path> -r json -o <output>."""
+    args = shlex.split(command or "scan -p . -r json")
+    if not args or args[0] != "scan":
+        args = ["scan", *args]
+
+    normalized: List[str] = ["scan"]
+    i = 1
+    has_path = False
+    has_report = False
+    has_output = False
+
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-p", "--path"):
+            if i + 1 < len(args):
+                normalized.extend([arg, args[i + 1]])
+                has_path = True
+                i += 2
+                continue
+        elif arg in ("-r", "--report-format"):
+            if i + 1 < len(args):
+                normalized.extend([arg, args[i + 1]])
+                has_report = True
+                i += 2
+                continue
+        elif arg in ("-o", "--output"):
+            if i + 1 < len(args):
+                normalized.extend([arg, args[i + 1]])
+                has_output = True
+                i += 2
+                continue
+        elif arg.startswith("-p") and len(arg) > 2:
+            normalized.append(arg)
+            has_path = True
+            i += 1
+            continue
+        i += 1
+
+    if not has_path:
+        normalized.extend(["-p", "."])
+    if not has_report:
+        normalized.extend(["-r", "json"])
+    if not has_output:
+        normalized.extend(["-o", output_file])
+    return normalized
+
+
+def discover_model_files(scan_root: str, cwd: Optional[str] = None) -> List[str]:
+    """Return model artifact paths under scan_root (or scan_root itself if it is a model file)."""
+    cwd = cwd or os.getcwd()
+    try:
+        path = resolve_path_within_root(scan_root, cwd)
+    except ValueError:
+        return []
+
+    if os.path.isfile(path):
+        return [path] if _is_model_file(path) else []
+
+    if not os.path.isdir(path):
+        return []
+
+    discovered: List[str] = []
+    for dirpath, dirnames, filenames in os.walk(path):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIR_NAMES and not d.startswith(".")]
+        for filename in filenames:
+            full_path = os.path.join(dirpath, filename)
+            if _is_model_file(full_path):
+                discovered.append(full_path)
+    return sorted(discovered)
+
+
+def _is_model_file(path: str) -> bool:
+    return os.path.splitext(path)[1].lower() in MODEL_EXTENSIONS
+
+
+def _parse_github_model_id(repo_url: Optional[str]) -> Optional[str]:
+    if not repo_url:
+        return None
+    repo_url = repo_url.strip().rstrip("/")
+    if repo_url.startswith("git@"):
+        match = re.match(r"git@[^:]+:([^/]+/[^/.]+)", repo_url)
+        return match.group(1) if match else None
+    if "://" in repo_url:
+        parsed = urlparse(repo_url)
+        parts = [p for p in parsed.path.strip("/").split("/") if p]
+        if len(parts) >= 2:
+            repo = parts[-1]
+            if repo.endswith(".git"):
+                repo = repo[:-4]
+            return f"{parts[-2]}/{repo}"
+    if "/" in repo_url and " " not in repo_url:
+        return repo_url.strip("/")
+    return None
+
+
+def derive_model_metadata(
+    repo_url: Optional[str],
+    commit_ref: Optional[str],
+    model_name: Optional[str] = None,
+    source_type: str = "github",
+) -> Dict[str, str]:
+    try:
+        cwd_name = os.path.basename(os.path.abspath(os.getcwd()))
+    except OSError:
+        cwd_name = "local"
+    model_id = _parse_github_model_id(repo_url) or repo_url or cwd_name
+    repository_name = model_id.split("/")[-1] if "/" in model_id else model_id
+    return {
+        "name": model_name or repository_name or cwd_name,
+        "model_id": model_id,
+        "source_type": source_type,
+        "repository_name": repository_name,
+        "commit_ref": commit_ref or "local",
+    }
+
+
+def build_model_path(
+    model_id: str,
+    commit_ref: str,
+    absolute_file_path: str,
+    scan_root: str,
+    cwd: Optional[str] = None,
+) -> str:
+    cwd = cwd or os.getcwd()
+    scan_root_abs = os.path.normpath(
+        scan_root if os.path.isabs(scan_root) else os.path.join(cwd, scan_root)
+    )
+    file_abs = os.path.normpath(absolute_file_path)
+    try:
+        relative = os.path.relpath(file_abs, scan_root_abs)
+    except ValueError:
+        relative = os.path.basename(file_abs)
+    if relative.startswith(".."):
+        relative = os.path.relpath(file_abs, cwd)
+    return f"{model_id}/{commit_ref}/{relative}".replace(os.sep, "/")
+
+
+def merge_modelscan_result(
+    modelscan_output: Dict[str, Any],
+    model_path: str,
+) -> Dict[str, Any]:
+    """Attach model_path to native modelscan JSON (issues[] preserved at top level)."""
+    merged = dict(modelscan_output)
+    merged["model_path"] = model_path
+    return merged
+
+
+def build_ondemand_modelscan_payload(
+    modelscan_results: List[Dict[str, Any]],
+    metadata: Dict[str, str],
+) -> Dict[str, Any]:
+    return {
+        "ondemand_modelscan": {
+            "name": metadata["name"],
+            "model_id": metadata["model_id"],
+            "source_type": metadata["source_type"],
+            "repository_name": metadata["repository_name"],
+            "modelscan_results": modelscan_results,
+        }
+    }
+
+
+def count_issues(modelscan_results: List[Dict[str, Any]]) -> int:
+    total = 0
+    for result in modelscan_results:
+        issues = result.get("issues")
+        if isinstance(issues, list):
+            total += len(issues)
+    return total
+
+
+def load_modelscan_output(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    return data if isinstance(data, dict) else {"issues": data}

--- a/aspm_cli/utils/path_safety.py
+++ b/aspm_cli/utils/path_safety.py
@@ -1,0 +1,21 @@
+import os
+from typing import Optional
+
+
+def resolve_path_within_root(path: str, root: Optional[str] = None) -> str:
+    """
+    Resolve path and ensure the result stays within root (prevents path traversal).
+    Raises ValueError when the resolved path escapes the scan root.
+    """
+    root = os.path.realpath(root or os.getcwd())
+    if not path or path in (".", ""):
+        return root
+
+    candidate = path if os.path.isabs(path) else os.path.join(root, path)
+    resolved = os.path.realpath(candidate)
+
+    if resolved != root and not resolved.startswith(root + os.sep):
+        raise ValueError(
+            f"Scan path '{path}' resolves outside the allowed directory '{root}'"
+        )
+    return resolved

--- a/aspm_cli/utils/sbom.py
+++ b/aspm_cli/utils/sbom.py
@@ -70,7 +70,10 @@ def derive_filesystem_component_display_name(
     """
     Human-readable BOM root name from host cwd and --command target (e.g. repo or repo/utils).
     """
-    cwd = cwd or os.getcwd()
+    try:
+        cwd = cwd or os.getcwd()
+    except OSError:
+        cwd = "."
     repo = os.path.basename(os.path.abspath(cwd))
     target = scan_target_from_command(command)
     if not target or target in (".", ""):
@@ -224,3 +227,25 @@ def normalize_sbom_args_for_docker(command: str, sanitized_args: List[str]) -> L
     if subcommand in FILESYSTEM_SUBCOMMANDS:
         return normalize_filesystem_args_for_docker(sanitized_args)
     return sanitized_args
+
+
+def is_sbom_payload_empty(data: Any) -> bool:
+    """Return True when CycloneDX payload has no meaningful BOM content."""
+    if not isinstance(data, dict) or not data:
+        return True
+    components = data.get("components")
+    if isinstance(components, list) and len(components) > 0:
+        return False
+    metadata = data.get("metadata")
+    if isinstance(metadata, dict) and metadata.get("component"):
+        return False
+    return True
+
+
+def append_sbom_scanner_flags(sanitized_args: List[str]) -> List[str]:
+    """Ensure SBOM scans request package + license analysis for richer CycloneDX output."""
+    if "--scanners" in sanitized_args:
+        return sanitized_args
+    result = list(sanitized_args)
+    result.extend(["--scanners", "vuln,license"])
+    return result

--- a/aspm_cli/utils/sca_prepare.py
+++ b/aspm_cli/utils/sca_prepare.py
@@ -1,0 +1,24 @@
+import json
+from typing import List
+
+
+def append_skip_git_dir(args: List[str]) -> List[str]:
+    """Ask Trivy not to walk .git during filesystem SCA scans."""
+    if not args or "--skip-dirs" in args:
+        return args
+    return [args[0], "--skip-dirs", ".git", *args[1:]]
+
+
+def normalize_sca_trivy_report(result_file: str) -> bool:
+    """
+    Trivy 0.69+ tags git checkouts as ArtifactType repository.
+    AccuKnox SCA parsing expects filesystem.
+    """
+    with open(result_file, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict) or data.get("ArtifactType") != "repository":
+        return False
+    data["ArtifactType"] = "filesystem"
+    with open(result_file, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2)
+    return True

--- a/aspm_cli/utils/subprocess_utils.py
+++ b/aspm_cli/utils/subprocess_utils.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+from typing import List, Optional
+
+DEFAULT_SCAN_TIMEOUT_SECONDS = 3600
+
+
+def scan_timeout_seconds() -> Optional[int]:
+    """Return subprocess timeout from SCAN_TIMEOUT_SECONDS, or default 1 hour."""
+    raw = os.getenv("SCAN_TIMEOUT_SECONDS", "").strip()
+    if not raw:
+        return DEFAULT_SCAN_TIMEOUT_SECONDS
+    try:
+        timeout = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            "SCAN_TIMEOUT_SECONDS must be a positive integer"
+        ) from exc
+    if timeout <= 0:
+        raise ValueError("SCAN_TIMEOUT_SECONDS must be a positive integer")
+    return timeout
+
+
+def run_scan_subprocess(cmd: List[str], **kwargs):
+    """Run a scanner subprocess with a configurable timeout."""
+    timeout = kwargs.pop("timeout", scan_timeout_seconds())
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        **kwargs,
+    )

--- a/aspm_cli/utils/validation.py
+++ b/aspm_cli/utils/validation.py
@@ -1,7 +1,16 @@
 from pydantic import BaseModel, Field, field_validator, model_validator
 from typing import Literal, Optional
 
-ALLOWED_TOOL_TYPES = ["iac", "sast", "secret", "container", "dast", "sq-sast", "codeassure"]
+ALLOWED_TOOL_TYPES = [
+    "iac",
+    "sast",
+    "secret",
+    "container",
+    "dast",
+    "sq-sast",
+    "codeassure",
+    "gitleaks",
+]
 
 class ToolDownloadConfig(BaseModel):
     tooltype: Optional[str] = Field(default=None)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = accuknox-aspm-scanner
-version = 0.14.6
+version = 0.15.0-rc.1
 description = AccuKnox ASPM Scanner
 author = AccuKnox
 author_email = accuknox@accuknox.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = accuknox-aspm-scanner
-version = 0.15.0-rc.1
+version = 0.14.7-rc.1
 description = AccuKnox ASPM Scanner
 author = AccuKnox
 author_email = accuknox@accuknox.com

--- a/utils/prepare-aspm-scanners.sh
+++ b/utils/prepare-aspm-scanners.sh
@@ -156,4 +156,23 @@ tar -czvf "$CODEASSURE_TAR" "$CODEASSURE_FOLDER"
 rm -rf "$TEMP_CODEASSURE" "$CODEASSURE_FOLDER"
 echo "✅ CodeAssure binary packaged as $CODEASSURE_TAR"
 
+### Gitleaks -> gitleaks.tar.gz
+echo "=== [8/8] Downloading Gitleaks ==="
+GITLEAKS_VERSION="8.24.2"
+GITLEAKS_TAR="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+GITLEAKS_URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${GITLEAKS_TAR}"
+GITLEAKS_BIN="gitleaks"
+GITLEAKS_ARCHIVE="gitleaks.tar.gz"
+
+mkdir -p temp_gitleaks_download
+cd temp_gitleaks_download
+curl -LO "$GITLEAKS_URL"
+tar -xzf "$GITLEAKS_TAR"
+cp gitleaks "../$GITLEAKS_BIN"
+cd ..
+tar -czvf "$GITLEAKS_ARCHIVE" "$GITLEAKS_BIN"
+cp temp_gitleaks_download/gitleaks $PACKAGE_BIN_DIR/$GITLEAKS_BIN
+rm -rf temp_gitleaks_download "$GITLEAKS_BIN"
+echo "✅ Packaged as $GITLEAKS_ARCHIVE"
+
 echo "🎉 All tools downloaded and prepared successfully."


### PR DESCRIPTION
## Summary

Adds Phase-1 ASPM scan types to `accuknox-aspm-scanner` and bumps version to **0.14.7-rc.1** for team pre-release testing.

**New scan types**
- **SCA** — Trivy filesystem dependency vulns (`data_type=TR`)
- **ML scan** — ModelScan via `ondemand_modelscan` image (`data_type=MLCHECKS`)
- **API discovery** — code2api static route discovery (`data_type=API`)
- **Secret** — `--engine gitleaks|trufflehog` (Gitleaks uploads as `TruffleHog` type)

**Enhancements**
- SAST: `--ai-analysis` via `ACCUKNOX_ENABLE_AI_SAST`
- SBOM/container: filesystem SBOM flags, empty-BOM guard, Trivy 0.69.3 handling
- Shared Trivy vuln runner for SCA (`trivy_runner.py`)
- Gitleaks binary packaging in `prepare-aspm-scanners.sh`

**Pre-release scope (container-first)**
- API discovery and ML scan are intended for **`--container-mode`** using published ECR images:
  - `public.ecr.aws/k9v9d5v2/accuknox/code2api:0.1.0`
  - `public.ecr.aws/k9v9d5v2/accuknox/ondemand_modelscan:1.0.21`
- Vendored `scanner-engines/` source, `api-discovery` tarball, and `tool install` for api-discovery **will be part of** (`v0.14.7`).
