### PR TITLE
chore(release): bump version to 0.14.7-rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It can upload results to the **AccuKnox ASPM Platform**, but it can also run in 
 Install from the GitHub release wheel:
 
 ```bash
-pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.6/accuknox_aspm_scanner-0.14.6-py3-none-any.whl
+pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.7-rc.1/accuknox_aspm_scanner-0.14.7rc1-py3-none-any.whl
 ```
 
 ### 2. Restricted or on-prem environment

--- a/aspm_cli/tool/download.py
+++ b/aspm_cli/tool/download.py
@@ -20,8 +20,8 @@ class ToolDownloader:
             "sq-sast": "https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.10.1/sq-sast.tar.gz",
             "sast": "https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.10.1/sast.tar.gz",
             "dast": "https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.10.1/dast.tar.gz",
-            "codeassure": "https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.6/codeassure.tar.gz",
-            "gitleaks": "https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.6/gitleaks.tar.gz",
+            "codeassure": "https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.7-rc.1/codeassure.tar.gz",
+            "gitleaks": "https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.7-rc.1/gitleaks.tar.gz",
         },
     }
 

--- a/aspm_cli/utils/version.py
+++ b/aspm_cli/utils/version.py
@@ -1,2 +1,2 @@
 def get_version():
-    return '0.14.6'
+    return '0.14.7-rc.1'

--- a/docs/onprem-setup-guide.md
+++ b/docs/onprem-setup-guide.md
@@ -54,7 +54,7 @@ These are only required when not using `--skip-upload`:
 Install the CLI from the GitHub release wheel:
 
 ```bash
-pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.6/accuknox_aspm_scanner-0.14.6-py3-none-any.whl
+pip install https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.7-rc.1/accuknox_aspm_scanner-0.14.7rc1-py3-none-any.whl
 ```
 
 ### Restricted or on-prem environment

--- a/utils/package/debian/changelog
+++ b/utils/package/debian/changelog
@@ -1,3 +1,11 @@
+aspm-scanner-cli (0.14.7-rc.1) unstable; urgency=medium
+
+  * Add Gitleaks secret scan with SARIF upload (data_type=DS)
+  * Phase-1 scan types: ML scan, API discovery, SCA/SBOM improvements
+  * Align CLI, wheel, and package version metadata to 0.14.7-rc.1
+
+ -- AccuKnox <accuknox@accuknox.com>  Fri, 19 Jun 2026 12:00:00 +0530
+
 aspm-scanner-cli (0.14.6) unstable; urgency=medium
 
   * Add --severity filtering for IaC scans


### PR DESCRIPTION
Align CLI version, release URLs, docs, and debian changelog with setup.cfg for the Phase-1 pre-release.